### PR TITLE
Introduce a typeclass for handling default values in protobuf messages

### DIFF
--- a/benchmarks/shared/src/main/scala/higherkindness/mu/rpc/benchmarks/shared/protocols/PersonServicePB.scala
+++ b/benchmarks/shared/src/main/scala/higherkindness/mu/rpc/benchmarks/shared/protocols/PersonServicePB.scala
@@ -21,6 +21,10 @@ package protocols
 import higherkindness.mu.rpc.benchmarks.shared.models._
 import higherkindness.mu.rpc.protocol._
 
+import cats.implicits._
+import cats.derived._
+import auto.monoid._
+
 @service(Protobuf)
 trait PersonServicePB[F[_]] {
 

--- a/build.sbt
+++ b/build.sbt
@@ -12,7 +12,6 @@ lazy val common = project
   .in(file("modules/common"))
   .settings(moduleName := "mu-common")
   .settings(commonSettings)
-  .settings(kittensTODO)
 
 lazy val `internal-core` = project
   .in(file("modules/internal"))
@@ -20,7 +19,6 @@ lazy val `internal-core` = project
   .dependsOn(testing % "test->test")
   .settings(moduleName := "mu-rpc-internal-core")
   .settings(internalSettings)
-  .settings(kittensTODO)
 
 lazy val `internal-monix` = project
   .in(file("modules/internal/monix"))
@@ -197,14 +195,14 @@ lazy val `benchmarks-vprev` = project
     libraryDependencies ++= Seq(
       "io.higherkindness" %% "mu-rpc-channel" % lastReleasedV,
       "io.higherkindness" %% "mu-rpc-server"  % lastReleasedV,
-      "io.higherkindness" %% "mu-rpc-testing" % lastReleasedV
+      "io.higherkindness" %% "mu-rpc-testing" % lastReleasedV,
+      "org.typelevel" %% "kittens" % "1.2.1"
     )
   )
   .settings(coverageEnabled := false)
   .settings(moduleName := "mu-benchmarks-vprev")
   .settings(crossSettings)
   .settings(noPublishSettings)
-  .settings(kittensTODO)
   .enablePlugins(JmhPlugin)
 
 lazy val `benchmarks-vnext` = project
@@ -216,7 +214,6 @@ lazy val `benchmarks-vnext` = project
   .settings(moduleName := "mu-benchmarks-vnext")
   .settings(crossSettings)
   .settings(noPublishSettings)
-  .settings(kittensTODO)
   .enablePlugins(JmhPlugin)
 
 //////////////////
@@ -233,7 +230,6 @@ lazy val `example-routeguide-protocol` = project
   .settings(coverageEnabled := false)
   .settings(noPublishSettings)
   .settings(moduleName := "mu-rpc-example-routeguide-protocol")
-  .settings(kittensTODO)
 
 lazy val `example-routeguide-runtime` = project
   .in(file("modules/examples/routeguide/runtime"))
@@ -321,7 +317,6 @@ lazy val `seed-server-protocol-avro` = project
   .in(file("modules/examples/seed/server/modules/protocol_avro"))
   .settings(coverageEnabled := false)
   .settings(noPublishSettings)
-  .settings(kittensTODO)
   .dependsOn(channel)
 
 lazy val `seed-server-protocol-proto` = project

--- a/build.sbt
+++ b/build.sbt
@@ -12,6 +12,7 @@ lazy val common = project
   .in(file("modules/common"))
   .settings(moduleName := "mu-common")
   .settings(commonSettings)
+  .settings(kittensTODO)
 
 lazy val `internal-core` = project
   .in(file("modules/internal"))
@@ -19,6 +20,7 @@ lazy val `internal-core` = project
   .dependsOn(testing % "test->test")
   .settings(moduleName := "mu-rpc-internal-core")
   .settings(internalSettings)
+  .settings(kittensTODO)
 
 lazy val `internal-monix` = project
   .in(file("modules/internal/monix"))
@@ -202,6 +204,7 @@ lazy val `benchmarks-vprev` = project
   .settings(moduleName := "mu-benchmarks-vprev")
   .settings(crossSettings)
   .settings(noPublishSettings)
+  .settings(kittensTODO)
   .enablePlugins(JmhPlugin)
 
 lazy val `benchmarks-vnext` = project
@@ -213,6 +216,7 @@ lazy val `benchmarks-vnext` = project
   .settings(moduleName := "mu-benchmarks-vnext")
   .settings(crossSettings)
   .settings(noPublishSettings)
+  .settings(kittensTODO)
   .enablePlugins(JmhPlugin)
 
 //////////////////
@@ -229,6 +233,7 @@ lazy val `example-routeguide-protocol` = project
   .settings(coverageEnabled := false)
   .settings(noPublishSettings)
   .settings(moduleName := "mu-rpc-example-routeguide-protocol")
+  .settings(kittensTODO)
 
 lazy val `example-routeguide-runtime` = project
   .in(file("modules/examples/routeguide/runtime"))
@@ -316,6 +321,7 @@ lazy val `seed-server-protocol-avro` = project
   .in(file("modules/examples/seed/server/modules/protocol_avro"))
   .settings(coverageEnabled := false)
   .settings(noPublishSettings)
+  .settings(kittensTODO)
   .dependsOn(channel)
 
 lazy val `seed-server-protocol-proto` = project

--- a/docs/src/main/tut/core-concepts.md
+++ b/docs/src/main/tut/core-concepts.md
@@ -91,11 +91,19 @@ case class Person(name: String, id: Int, has_ponycopter: Boolean)
 
 As we can see, this is quite simple - it’s just a Scala case class preceded by the `@message` annotation (though, `@message` is optional and used exclusively by `idlGen`):
 
-By the same token, let’s see now how the `Greeter` service would be translated to the [mu] style (in your `.scala` file):
+By the same token, let’s see now how the `Greeter` service would be translated to the [mu] style (in your `.scala` file). We need to include an instance of the `ProtoDefault` typeclass for the request, so that the server knows how to generate default values. For efficiency, gRPC defaults are not sent over the wire, so the server needs to fill them in. If you have an implicit `cats.Monoid` in scope for your type, the compiler can use that too.
 
 ```tut:silent
 object protocol {
 
+  implicit val helloRequestDefault: ProtoDefault[HelloRequest] = new ProtoDefault[HelloRequest] {
+    val default: HelloRequest = HelloRequest("")
+  }
+  
+  implicit val helloReplyDefault: ProtoDefault[HelloReply] = new ProtoDefault[HelloReply] {
+    val default: HelloReply = HelloReply("")
+  }
+  
   /**
     * The request message containing the user's name.
     * @param name User's name.
@@ -139,6 +147,14 @@ For instance:
 
 ```tut:silent
 object protocol {
+
+  implicit val helloRequestDefault: ProtoDefault[HelloRequest] = new ProtoDefault[HelloRequest] {
+    val default: HelloRequest = HelloRequest("")
+  }
+
+  implicit val helloReplyDefault: ProtoDefault[HelloReply] = new ProtoDefault[HelloReply] {
+    val default: HelloReply = HelloReply("")
+  }
 
   /**
    * The request message containing the user's name.
@@ -265,6 +281,14 @@ Let's complete our protocol's example with an unary service method:
 ```tut:silent
 object service {
 
+  implicit val helloRequestDefault: ProtoDefault[HelloRequest] = new ProtoDefault[HelloRequest] {
+    val default: HelloRequest = HelloRequest("")
+  }
+
+  implicit val helloResponseDefault: ProtoDefault[HelloResponse] = new ProtoDefault[HelloResponse] {
+    val default: HelloResponse = HelloResponse("")
+  }
+
   @message
   case class HelloRequest(greeting: String)
 
@@ -319,6 +343,14 @@ object protocol {
   implicit object LocalDateReader extends PBReader[LocalDate] {
     override def read(input: CodedInputStream): LocalDate =
       LocalDate.parse(input.readString(), DateTimeFormatter.ISO_LOCAL_DATE)
+  }
+
+  implicit val helloRequestDefault: ProtoDefault[HelloRequest] = new ProtoDefault[HelloRequest] {
+    val default: HelloRequest = HelloRequest("", LocalDate.MIN)
+  }
+
+  implicit val helloReplyDefault: ProtoDefault[HelloReply] = new ProtoDefault[HelloReply] {
+    val default: HelloReply = HelloReply("")
   }
 
   @message

--- a/docs/src/main/tut/idl-generation.md
+++ b/docs/src/main/tut/idl-generation.md
@@ -41,6 +41,14 @@ object service {
 
   import monix.reactive.Observable
 
+  implicit val helloRequestDefault: ProtoDefault[HelloRequest] = new ProtoDefault[HelloRequest] {
+    val default: HelloRequest = HelloRequest("")
+  }
+  
+  implicit val helloResponseDefault: ProtoDefault[HelloResponse] = new ProtoDefault[HelloResponse] {
+    val default: HelloResponse = HelloResponse("")
+  }
+  
   @message
   case class HelloRequest(greeting: String)
 

--- a/docs/src/main/tut/metrics-reporting.md
+++ b/docs/src/main/tut/metrics-reporting.md
@@ -34,6 +34,15 @@ import higherkindness.mu.rpc.protocol._
 
 object service {
 
+  implicit val helloRequestDefault: ProtoDefault[HelloRequest] = new ProtoDefault[HelloRequest] {
+    val default: HelloRequest = HelloRequest("")
+  }
+  
+  implicit val helloReplyDefault: ProtoDefault[HelloResponse] = new ProtoDefault[HelloResponse] {
+    val default: HelloResponse = HelloResponse("")
+  }
+  
+
   @message
   case class HelloRequest(greeting: String)
 

--- a/docs/src/main/tut/patterns.md
+++ b/docs/src/main/tut/patterns.md
@@ -21,6 +21,14 @@ object service {
 
   import monix.reactive.Observable
 
+  implicit val helloRequestDefault: ProtoDefault[HelloRequest] = new ProtoDefault[HelloRequest] {
+    val default: HelloRequest = HelloRequest("")
+  }
+  
+  implicit val helloResponseDefault: ProtoDefault[HelloResponse] = new ProtoDefault[HelloResponse] {
+    val default: HelloResponse = HelloResponse("")
+  }
+  
   @message
   case class HelloRequest(greeting: String)
 

--- a/docs/src/main/tut/ssl-tls.md
+++ b/docs/src/main/tut/ssl-tls.md
@@ -49,6 +49,14 @@ import higherkindness.mu.rpc.protocol._
 
 object service {
 
+  implicit val helloRequestDefault: ProtoDefault[HelloRequest] = new ProtoDefault[HelloRequest] {
+    val default: HelloRequest = HelloRequest("")
+  }
+  
+  implicit val helloResponseDefault: ProtoDefault[HelloResponse] = new ProtoDefault[HelloResponse] {
+    val default: HelloResponse = HelloResponse("")
+  }
+  
   @message
   case class HelloRequest(greeting: String)
 

--- a/docs/src/main/tut/streaming.md
+++ b/docs/src/main/tut/streaming.md
@@ -21,6 +21,14 @@ object service {
 
   import monix.reactive.Observable
 
+  implicit val helloRequestDefault: ProtoDefault[HelloRequest] = new ProtoDefault[HelloRequest] {
+    val default: HelloRequest = HelloRequest("")
+  }
+  
+  implicit val helloResponseDefault: ProtoDefault[HelloResponse] = new ProtoDefault[HelloResponse] {
+    val default: HelloResponse = HelloResponse("")
+  }
+  
   @message
   case class HelloRequest(greeting: String)
 
@@ -103,6 +111,14 @@ object service {
 
   import fs2.Stream
 
+  implicit val helloRequestDefault: ProtoDefault[HelloRequest] = new ProtoDefault[HelloRequest] {
+    val default: HelloRequest = HelloRequest("")
+  }
+  
+  implicit val helloResponseDefault: ProtoDefault[HelloResponse] = new ProtoDefault[HelloResponse] {
+    val default: HelloResponse = HelloResponse("")
+  }
+  
   @message
   case class HelloRequest(greeting: String)
 

--- a/modules/channel/src/test/scala/higherkindness/mu/rpc/channel/metrics/MonitoringChannelInterceptorTests.scala
+++ b/modules/channel/src/test/scala/higherkindness/mu/rpc/channel/metrics/MonitoringChannelInterceptorTests.scala
@@ -130,6 +130,10 @@ object services {
   implicit val timer: cats.effect.Timer[cats.effect.IO]     = cats.effect.IO.timer(EC)
   implicit val cs: cats.effect.ContextShift[cats.effect.IO] = cats.effect.IO.contextShift(EC)
 
+  import cats.implicits._
+  import cats.derived._
+  import auto.monoid._
+
   final case class Request()
   final case class Response()
 

--- a/modules/common/src/main/scala/higherkindness/mu/rpc/protocol/ProtoDefault.scala
+++ b/modules/common/src/main/scala/higherkindness/mu/rpc/protocol/ProtoDefault.scala
@@ -35,4 +35,8 @@ object ProtoDefault {
   implicit val protoDefaultBigDecimal: ProtoDefault[BigDecimal] = new ProtoDefault[BigDecimal] {
     def default: BigDecimal = BigDecimal(0)
   }
+
+  implicit val protoDefaultMuEmpty: ProtoDefault[Empty.type] = new ProtoDefault[Empty.type] {
+    override def default: Empty.type = Empty
+  }
 }

--- a/modules/common/src/main/scala/higherkindness/mu/rpc/protocol/ProtoDefault.scala
+++ b/modules/common/src/main/scala/higherkindness/mu/rpc/protocol/ProtoDefault.scala
@@ -14,33 +14,25 @@
  * limitations under the License.
  */
 
-package examples.todolist
-package protocol
+package higherkindness.mu.rpc.protocol
 
-import cats.implicits._
-import cats.derived._
-import auto.monoid._
-import higherkindness.mu.rpc.protocol._
+import cats.Monoid
 
-trait PingPongProtocol {
+trait ProtoDefault[A] {
+  def default: A
+}
 
-  /**
-   * Pong response with current timestamp
-   *
-   * @param time Current timestamp.
-   */
-  case class Pong(time: Long = System.currentTimeMillis() / 1000L)
+object ProtoDefault {
+  def apply[A](implicit P: ProtoDefault[A]): ProtoDefault[A] = P
 
-  @service(Protobuf)
-  trait PingPongService[F[_]] {
+  implicit def protoDefaultFromMonoid[A](implicit M: Monoid[A]): ProtoDefault[A] =
+    new ProtoDefault[A] { def default: A = M.empty }
 
-    /**
-     * A simple ping-pong rpc.
-     *
-     * @param empty
-     * @return Pong response with current timestamp.
-     */
-    def ping(empty: Empty.type): F[Pong]
+  implicit val protoDefaultBoolean: ProtoDefault[Boolean] = new ProtoDefault[Boolean] {
+    def default: Boolean = false
+  }
 
+  implicit val protoDefaultBigDecimal: ProtoDefault[BigDecimal] = new ProtoDefault[BigDecimal] {
+    def default: BigDecimal = BigDecimal(0)
   }
 }

--- a/modules/examples/routeguide/protocol/src/main/scala/Protocols.scala
+++ b/modules/examples/routeguide/protocol/src/main/scala/Protocols.scala
@@ -19,6 +19,10 @@ package example.routeguide.protocol
 import higherkindness.mu.rpc.protocol._
 import monix.reactive.Observable
 
+import cats.implicits._
+import cats.derived._
+import auto.monoid._
+
 @outputPackage("routeguide")
 @option("java_multiple_files", true)
 @option("java_package", "io.grpc.examples.routeguide")

--- a/modules/examples/seed/server/modules/protocol_proto/src/main/scala/people.scala
+++ b/modules/examples/seed/server/modules/protocol_proto/src/main/scala/people.scala
@@ -22,6 +22,20 @@ object people {
 
   @message final case class Person(name: String, age: Int)
   @message final case class PeopleRequest(name: String)
+
+  object PeopleRequest {
+    implicit val protoDefaultPeopleRequest: ProtoDefault[PeopleRequest] =
+      new ProtoDefault[PeopleRequest] {
+        def default: PeopleRequest = PeopleRequest("")
+      }
+  }
+
   @message final case class PeopleResponse(person: Person)
 
+  object PeopleResponse {
+    implicit val protoDefaultPeopleResponse: ProtoDefault[PeopleResponse] =
+      new ProtoDefault[PeopleResponse] {
+        def default: PeopleResponse = PeopleResponse(Person("", 0))
+      }
+  }
 }

--- a/modules/internal/src/main/scala/higherkindness/mu/rpc/internal/serviceImpl.scala
+++ b/modules/internal/src/main/scala/higherkindness/mu/rpc/internal/serviceImpl.scala
@@ -379,11 +379,21 @@ object serviceImpl {
 
         private val respType = response.safeInner
 
+        //q"""ReqPD: _root_.higherkindness.mu.rpc.protocol.ProtoDefault[$reqType],"""
+
+        val methodDescriptorMarshallerImplicits: List[Tree] = List(
+          q"ReqM: _root_.io.grpc.MethodDescriptor.Marshaller[$reqType]",
+          q"RespM: _root_.io.grpc.MethodDescriptor.Marshaller[$respType]"
+        )
+
+        val methodDescriptorProtoDefaultImplicit: List[Tree] = if (serializationType == Protobuf) {
+          List(q"ReqPD: _root_.higherkindness.mu.rpc.protocol.ProtoDefault[$reqType]")
+        } else List()
+
+        val methodDescriptorImplicits = methodDescriptorMarshallerImplicits ++ methodDescriptorProtoDefaultImplicit
+
         val methodDescriptor: DefDef = q"""
-          def $methodDescriptorName(implicit
-            ReqM: _root_.io.grpc.MethodDescriptor.Marshaller[$reqType],
-            RespM: _root_.io.grpc.MethodDescriptor.Marshaller[$respType]
-          ): _root_.io.grpc.MethodDescriptor[$reqType, $respType] = {
+          def $methodDescriptorName(implicit ..$methodDescriptorImplicits): _root_.io.grpc.MethodDescriptor[$reqType, $respType] = {
             _root_.io.grpc.MethodDescriptor
               .newBuilder(
                 ReqM,

--- a/modules/internal/src/main/scala/higherkindness/mu/rpc/internal/serviceImpl.scala
+++ b/modules/internal/src/main/scala/higherkindness/mu/rpc/internal/serviceImpl.scala
@@ -379,8 +379,6 @@ object serviceImpl {
 
         private val respType = response.safeInner
 
-        //q"""ReqPD: _root_.higherkindness.mu.rpc.protocol.ProtoDefault[$reqType],"""
-
         val methodDescriptorMarshallerImplicits: List[Tree] = List(
           q"ReqM: _root_.io.grpc.MethodDescriptor.Marshaller[$reqType]",
           q"RespM: _root_.io.grpc.MethodDescriptor.Marshaller[$respType]"

--- a/modules/internal/src/test/scala/higherkindness/mu/rpc/internal/encoders/DefaultPBDirectMarshallerTests.scala
+++ b/modules/internal/src/test/scala/higherkindness/mu/rpc/internal/encoders/DefaultPBDirectMarshallerTests.scala
@@ -1,0 +1,75 @@
+/*
+ * Copyright 2017-2019 47 Degrees, LLC. <http://www.47deg.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package higherkindness.mu.rpc.internal.encoders
+
+import java.io.{ByteArrayInputStream, InputStream}
+
+import cats.implicits._
+import cats.kernel.Monoid
+import higherkindness.mu.rpc.internal.encoders.pbd._
+import higherkindness.mu.rpc.protocol.ProtoDefault
+import io.grpc.MethodDescriptor.Marshaller
+import org.scalatest._
+
+class DefaultPBDirectMarshallerTests extends WordSpec with Matchers {
+
+  case class MyTestDefault(s: String)
+  private val expectedString = "12345"
+
+  private val emptyInputStream: InputStream = new ByteArrayInputStream(Array())
+
+  private def testDefault[A](expectedDefault: A)(implicit M: Marshaller[A]) =
+    M.parse(emptyInputStream) shouldBe expectedDefault
+
+  "Default pbd marshaller" should {
+
+    "handle empty streams by filling in the default value" in {
+      testDefault[Float](0.0f)
+      testDefault[Double](0.0)
+      testDefault[Boolean](false)
+      testDefault[Int](0)
+      testDefault[Long](0)
+      testDefault[String]("")
+    }
+
+    "handle empty streams by filling in the default value when a ProtoDefault typeclass exists" in {
+      implicit val protoDefault: ProtoDefault[MyTestDefault] = new ProtoDefault[MyTestDefault] {
+        override def default: MyTestDefault = MyTestDefault(expectedString)
+      }
+
+      testDefault[MyTestDefault](MyTestDefault(expectedString))
+    }
+
+    "handle empty streams by filling in the default value when a Monoid typeclass exists" in {
+      implicit val monoid: Monoid[MyTestDefault] = new Monoid[MyTestDefault] {
+        override def empty: MyTestDefault = MyTestDefault(expectedString)
+
+        override def combine(x: MyTestDefault, y: MyTestDefault): MyTestDefault =
+          ??? // explicit as it should never be called
+      }
+
+      testDefault[MyTestDefault](MyTestDefault(expectedString))
+    }
+
+    "handle empty streams by filling in the default when an automatically derived Monoid typeclass exists" in {
+      import cats.derived._
+      import auto.monoid._
+
+      testDefault[MyTestDefault](MyTestDefault(""))
+    }
+  }
+}

--- a/modules/marshallers/jodatime/src/test/scala/higherkindness/mu/rpc/protocol/RPCJodaLocalDateTests.scala
+++ b/modules/marshallers/jodatime/src/test/scala/higherkindness/mu/rpc/protocol/RPCJodaLocalDateTests.scala
@@ -50,6 +50,19 @@ class RPCJodaLocalDateTests extends RpcBaseTestSuite with BeforeAndAfterAll with
 
     object ProtobufService {
       import higherkindness.mu.rpc.marshallers.jodaTimeEncoders.pbd._
+
+      implicit val protoDefaultLocalDate: ProtoDefault[LocalDate] = new ProtoDefault[LocalDate] {
+        override def default: LocalDate = new LocalDate(1970, 1, 1)
+      }
+
+      implicit val protoDefaultRequest: ProtoDefault[Request] = new ProtoDefault[Request] {
+        override def default: Request = Request(new LocalDate(1970, 1, 1), "")
+      }
+
+      implicit val protoDefaultResponse: ProtoDefault[Response] = new ProtoDefault[Response] {
+        override def default: Response = Response(new LocalDate(1970, 1, 1), "", false)
+      }
+
       @service(Protobuf)
       trait Def[F[_]] {
         def jodaLocalDateProto(date: LocalDate): F[LocalDate]

--- a/modules/marshallers/jodatime/src/test/scala/higherkindness/mu/rpc/protocol/RPCJodaLocalDateTimeTests.scala
+++ b/modules/marshallers/jodatime/src/test/scala/higherkindness/mu/rpc/protocol/RPCJodaLocalDateTimeTests.scala
@@ -44,6 +44,19 @@ class RPCJodaLocalDateTimeTests extends RpcBaseTestSuite with BeforeAndAfter wit
 
   object RPCJodaLocalDateTimeService {
 
+    implicit val protoDefaultLocalDateTime: ProtoDefault[LocalDateTime] =
+      new ProtoDefault[LocalDateTime] {
+        override def default: LocalDateTime = new LocalDateTime(0L)
+      }
+
+    implicit val protoDefaultRequest: ProtoDefault[Request] = new ProtoDefault[Request] {
+      override def default: Request = Request(new LocalDateTime(0L), "")
+    }
+
+    implicit val protoDefaultResponse: ProtoDefault[Response] = new ProtoDefault[Response] {
+      override def default: Response = Response(new LocalDateTime(0L), "", false)
+    }
+
     case class Request(date: LocalDateTime, label: String)
 
     case class Response(date: LocalDateTime, label: String, check: Boolean)

--- a/modules/server/src/test/scala/higherkindness/mu/rpc/fs2/Utils.scala
+++ b/modules/server/src/test/scala/higherkindness/mu/rpc/fs2/Utils.scala
@@ -27,6 +27,10 @@ object Utils extends CommonUtils {
 
   object service {
 
+    import cats.implicits._
+    import cats.derived._
+    import auto.monoid._
+
     @service(Protobuf) trait ProtoRPCService[F[_]] {
       def serverStreamingWithError(e: E): Stream[F, C]
       def clientStreaming(oa: Stream[F, A]): F[D]

--- a/modules/server/src/test/scala/higherkindness/mu/rpc/protocol/RPCAnnotationParamTests.scala
+++ b/modules/server/src/test/scala/higherkindness/mu/rpc/protocol/RPCAnnotationParamTests.scala
@@ -22,6 +22,10 @@ import org.scalatestplus.scalacheck.Checkers
 
 class RPCAnnotationParamTests extends RpcBaseTestSuite with BeforeAndAfterAll with Checkers {
 
+  import cats.implicits._
+  import cats.derived._
+  import auto.monoid._
+
   case class Request(s: String)
   case class Response(length: Int)
 

--- a/modules/server/src/test/scala/higherkindness/mu/rpc/protocol/RPCBigDecimalTests.scala
+++ b/modules/server/src/test/scala/higherkindness/mu/rpc/protocol/RPCBigDecimalTests.scala
@@ -51,6 +51,14 @@ class RPCBigDecimalTests extends RpcBaseTestSuite with BeforeAndAfterAll with Ch
 
   object RPCService {
 
+    implicit val protoDefaultRequest: ProtoDefault[Request] = new ProtoDefault[Request] {
+      override def default: Request = Request(BigDecimal(0), "")
+    }
+
+    implicit val protoDefaultResponse: ProtoDefault[Response] = new ProtoDefault[Response] {
+      override def default: Response = Response(BigDecimal(0), "", false)
+    }
+
     case class Request(bigDecimal: BigDecimal, label: String)
 
     case class Response(bigDecimal: BigDecimal, result: String, check: Boolean)

--- a/modules/server/src/test/scala/higherkindness/mu/rpc/protocol/RPCBigDecimalTests.scala
+++ b/modules/server/src/test/scala/higherkindness/mu/rpc/protocol/RPCBigDecimalTests.scala
@@ -56,7 +56,7 @@ class RPCBigDecimalTests extends RpcBaseTestSuite with BeforeAndAfterAll with Ch
     }
 
     implicit val protoDefaultResponse: ProtoDefault[Response] = new ProtoDefault[Response] {
-      override def default: Response = Response(BigDecimal(0), "", false)
+      override def default: Response = Response(BigDecimal(0), "", check = false)
     }
 
     case class Request(bigDecimal: BigDecimal, label: String)

--- a/modules/server/src/test/scala/higherkindness/mu/rpc/protocol/RPCJavaTimeTests.scala
+++ b/modules/server/src/test/scala/higherkindness/mu/rpc/protocol/RPCJavaTimeTests.scala
@@ -49,7 +49,7 @@ class RPCJavaTimeTests extends RpcBaseTestSuite with BeforeAndAfterAll with Chec
 
     implicit val protoDefaultResponse: ProtoDefault[Response] = new ProtoDefault[Response] {
       override def default: Response =
-        Response(ld, ldt, Instant.now(), "", false)
+        Response(ld, ldt, Instant.now(), "", check = false)
     }
 
     case class Request(date: LocalDate, dateTime: LocalDateTime, instant: Instant, label: String)

--- a/modules/server/src/test/scala/higherkindness/mu/rpc/protocol/RPCJavaTimeTests.scala
+++ b/modules/server/src/test/scala/higherkindness/mu/rpc/protocol/RPCJavaTimeTests.scala
@@ -38,6 +38,20 @@ class RPCJavaTimeTests extends RpcBaseTestSuite with BeforeAndAfterAll with Chec
 
   object RPCDateService {
 
+    val ld  = LocalDate.of(1970, 1, 1)
+    val lt  = LocalTime.of(0, 0, 0, 0)
+    val ldt = LocalDateTime.of(ld, lt)
+
+    implicit val protoDefaultRequest: ProtoDefault[Request] = new ProtoDefault[Request] {
+      override def default: Request =
+        Request(ld, ldt, Instant.now(), "")
+    }
+
+    implicit val protoDefaultResponse: ProtoDefault[Response] = new ProtoDefault[Response] {
+      override def default: Response =
+        Response(ld, ldt, Instant.now(), "", false)
+    }
+
     case class Request(date: LocalDate, dateTime: LocalDateTime, instant: Instant, label: String)
 
     case class Response(

--- a/modules/server/src/test/scala/higherkindness/mu/rpc/protocol/RPCMethodNameTests.scala
+++ b/modules/server/src/test/scala/higherkindness/mu/rpc/protocol/RPCMethodNameTests.scala
@@ -28,13 +28,10 @@ class RPCMethodNameTests extends RpcBaseTestSuite with BeforeAndAfterAll with Ch
 
   object RPCService {
 
-    implicit val protoDefaultRequest: ProtoDefault[Request] = new ProtoDefault[Request] {
-      override def default: Request = Request("")
-    }
-
-    implicit val protoDefaultResponse: ProtoDefault[Response] = new ProtoDefault[Response] {
-      override def default: Response = Response(0)
-    }
+    import cats.kernel.instances.string._
+    import cats.kernel.instances.int._
+    import cats.derived._
+    import auto.monoid._
 
     case class Request(s: String)
 

--- a/modules/server/src/test/scala/higherkindness/mu/rpc/protocol/RPCMethodNameTests.scala
+++ b/modules/server/src/test/scala/higherkindness/mu/rpc/protocol/RPCMethodNameTests.scala
@@ -28,6 +28,14 @@ class RPCMethodNameTests extends RpcBaseTestSuite with BeforeAndAfterAll with Ch
 
   object RPCService {
 
+    implicit val protoDefaultRequest: ProtoDefault[Request] = new ProtoDefault[Request] {
+      override def default: Request = Request("")
+    }
+
+    implicit val protoDefaultResponse: ProtoDefault[Response] = new ProtoDefault[Response] {
+      override def default: Response = Response(0)
+    }
+
     case class Request(s: String)
 
     case class Response(length: Int)

--- a/modules/server/src/test/scala/higherkindness/mu/rpc/protocol/RPCNamespaceTests.scala
+++ b/modules/server/src/test/scala/higherkindness/mu/rpc/protocol/RPCNamespaceTests.scala
@@ -28,6 +28,14 @@ class RPCNamespaceTests extends RpcBaseTestSuite with BeforeAndAfterAll with Che
 
   object RPCService {
 
+    implicit val protoDefaultRequest: ProtoDefault[Request] = new ProtoDefault[Request] {
+      override def default: Request = Request("")
+    }
+
+    implicit val protoDefaultResponse: ProtoDefault[Response] = new ProtoDefault[Response] {
+      override def default: Response = Response(0)
+    }
+
     case class Request(s: String)
 
     case class Response(length: Int)

--- a/modules/server/src/test/scala/higherkindness/mu/rpc/protocol/RPCProtoProducts.scala
+++ b/modules/server/src/test/scala/higherkindness/mu/rpc/protocol/RPCProtoProducts.scala
@@ -41,12 +41,12 @@ class RPCProtoProducts extends RpcBaseTestSuite with BeforeAndAfterAll with Chec
 
     implicit val protoDefaultResponseOption: ProtoDefault[ResponseOption] =
       new ProtoDefault[ResponseOption] {
-        override def default: ResponseOption = ResponseOption(None, false)
+        override def default: ResponseOption = ResponseOption(None, param2 = false)
       }
 
     implicit val protoDefaultResponseList: ProtoDefault[ResponseList] =
       new ProtoDefault[ResponseList] {
-        override def default: ResponseList = ResponseList(Nil, false)
+        override def default: ResponseList = ResponseList(Nil, param2 = false)
       }
 
     case class MyParam(value: String)

--- a/modules/server/src/test/scala/higherkindness/mu/rpc/protocol/RPCProtoProducts.scala
+++ b/modules/server/src/test/scala/higherkindness/mu/rpc/protocol/RPCProtoProducts.scala
@@ -29,6 +29,26 @@ class RPCProtoProducts extends RpcBaseTestSuite with BeforeAndAfterAll with Chec
 
   object RPCService {
 
+    implicit val protoDefaultRequestOption: ProtoDefault[RequestOption] =
+      new ProtoDefault[RequestOption] {
+        override def default: RequestOption = RequestOption(None)
+      }
+
+    implicit val protoDefaultRequestList: ProtoDefault[RequestList] =
+      new ProtoDefault[RequestList] {
+        override def default: RequestList = RequestList(Nil)
+      }
+
+    implicit val protoDefaultResponseOption: ProtoDefault[ResponseOption] =
+      new ProtoDefault[ResponseOption] {
+        override def default: ResponseOption = ResponseOption(None, false)
+      }
+
+    implicit val protoDefaultResponseList: ProtoDefault[ResponseList] =
+      new ProtoDefault[ResponseList] {
+        override def default: ResponseList = ResponseList(Nil, false)
+      }
+
     case class MyParam(value: String)
 
     case class RequestOption(param1: Option[MyParam])

--- a/modules/server/src/test/scala/higherkindness/mu/rpc/protocol/Utils.scala
+++ b/modules/server/src/test/scala/higherkindness/mu/rpc/protocol/Utils.scala
@@ -28,6 +28,11 @@ import monix.execution.Scheduler
 object Utils extends CommonUtils {
 
   object service {
+
+    import cats.implicits._
+    import cats.derived._
+    import auto.monoid._
+
     @service(Avro, Gzip) trait CompressedAvroRPCService[F[_]] {
       def unaryCompressed(a: A): F[C]
       def unaryCompressedWithError(e: E): F[C]

--- a/modules/server/src/test/scala/higherkindness/mu/rpc/server/metrics/MetricsServerInterceptorTests.scala
+++ b/modules/server/src/test/scala/higherkindness/mu/rpc/server/metrics/MetricsServerInterceptorTests.scala
@@ -124,13 +124,8 @@ object services {
   implicit val timer: cats.effect.Timer[cats.effect.IO]     = cats.effect.IO.timer(EC)
   implicit val cs: cats.effect.ContextShift[cats.effect.IO] = cats.effect.IO.contextShift(EC)
 
-  implicit val protoDefaultRequest: ProtoDefault[Request] = new ProtoDefault[Request] {
-    override def default: Request = Request()
-  }
-
-  implicit val protoDefaultResponse: ProtoDefault[Response] = new ProtoDefault[Response] {
-    override def default: Response = Response()
-  }
+  import cats.derived._
+  import auto.monoid._
 
   final case class Request()
   final case class Response()

--- a/modules/server/src/test/scala/higherkindness/mu/rpc/server/metrics/MetricsServerInterceptorTests.scala
+++ b/modules/server/src/test/scala/higherkindness/mu/rpc/server/metrics/MetricsServerInterceptorTests.scala
@@ -124,6 +124,14 @@ object services {
   implicit val timer: cats.effect.Timer[cats.effect.IO]     = cats.effect.IO.timer(EC)
   implicit val cs: cats.effect.ContextShift[cats.effect.IO] = cats.effect.IO.contextShift(EC)
 
+  implicit val protoDefaultRequest: ProtoDefault[Request] = new ProtoDefault[Request] {
+    override def default: Request = Request()
+  }
+
+  implicit val protoDefaultResponse: ProtoDefault[Response] = new ProtoDefault[Response] {
+    override def default: Response = Response()
+  }
+
   final case class Request()
   final case class Response()
 

--- a/project/ProjectPlugin.scala
+++ b/project/ProjectPlugin.scala
@@ -60,6 +60,7 @@ object ProjectPlugin extends AutoPlugin {
     lazy val commonSettings: Seq[Def.Setting[_]] = Seq(
       libraryDependencies ++= Seq(
         %%("cats-effect", V.catsEffect),
+        "org.typelevel" %% "kittens" % "1.2.1",
         %%("scalamockScalatest")                         % Test,
         %%("scheckToolboxDatetime", V.scalacheckToolbox) % Test
       )
@@ -193,12 +194,6 @@ object ProjectPlugin extends AutoPlugin {
       libraryDependencies ++= Seq(
         %("joda-time", V.jodaTime),
         %%("scheckToolboxDatetime", V.scalacheckToolbox) % Test
-      )
-    )
-
-    lazy val kittensTODO: Seq[Def.Setting[_]] = Seq(
-      libraryDependencies ++= Seq(
-        "org.typelevel" %% "kittens" % "1.2.1" // todo this should go in a better place but it's fine for now before PR
       )
     )
 

--- a/project/ProjectPlugin.scala
+++ b/project/ProjectPlugin.scala
@@ -59,7 +59,7 @@ object ProjectPlugin extends AutoPlugin {
 
     lazy val commonSettings: Seq[Def.Setting[_]] = Seq(
       libraryDependencies ++= Seq(
-        %%("cats-effect", V.catsEffect)                  % Test,
+        %%("cats-effect", V.catsEffect),
         %%("scalamockScalatest")                         % Test,
         %%("scheckToolboxDatetime", V.scalacheckToolbox) % Test
       )
@@ -193,6 +193,12 @@ object ProjectPlugin extends AutoPlugin {
       libraryDependencies ++= Seq(
         %("joda-time", V.jodaTime),
         %%("scheckToolboxDatetime", V.scalacheckToolbox) % Test
+      )
+    )
+
+    lazy val kittensTODO: Seq[Def.Setting[_]] = Seq(
+      libraryDependencies ++= Seq(
+        "org.typelevel" %% "kittens" % "1.2.1" // todo this should go in a better place but it's fine for now before PR
       )
     )
 


### PR DESCRIPTION
## What this does?
Introduce a `ProtoDefault` typeclass for handling default values, as required in #606.

Originally I was changing the call to `pbTo` from the `A` type to an `Option[A]` wrapped in a case class, but this was not playing nice with some particular option types when sent over the wire, similar to the tests found in `higherkindness.mu.rpc.protocol.RPCProtoProducts`, so I think it is fine here to wrap the call in a `Try`, and if that fails, return the default. I did make a start on changing pbdirect to return `Option[A]` rather than `A` for its parsing methods, but the approach I've taken feels to be the least invasive to fix the underlying bug.

The `ProtoDefault` has one field, `default`, and this can be derived from a `cats.Monoid` if there's one in scope. For the majority of defaults needed throughout the project, I have pulled in the Typelevel Kittens project to automatically derive a `Monoid` instance.

## Checklist

- [x] Reviewed the diff to look for typos, println and format errors.
- [x] Updated the docs accordingly.

