### PR TITLE
Scalameta codegen

### DIFF
--- a/modules/idlgen/core/src/test/scala/higherkindness/mu/rpc/idlgen/ProtoSrcGenTests.scala
+++ b/modules/idlgen/core/src/test/scala/higherkindness/mu/rpc/idlgen/ProtoSrcGenTests.scala
@@ -62,6 +62,7 @@ class ProtoSrcGenTests extends RpcBaseTestSuite with OptionValues {
 
       val expectedFileContent =
         bookExpectation(tpe => s"_root_.monix.reactive.Observable[$tpe]").clean
+
       result shouldBe Some(("com/proto/book.scala", expectedFileContent))
     }
 
@@ -70,7 +71,7 @@ class ProtoSrcGenTests extends RpcBaseTestSuite with OptionValues {
   def bookExpectation(streamOf: String => String): String =
     s"""package com.proto
       |
-      |import higherkindness.mu.rpc.protocol._
+      |import _root_.higherkindness.mu.rpc.protocol._
       |
       |object book {
       |

--- a/project/ProjectPlugin.scala
+++ b/project/ProjectPlugin.scala
@@ -59,7 +59,7 @@ object ProjectPlugin extends AutoPlugin {
       val scalacheckToolbox: String  = "0.3.1"
       val scalamock: String          = "4.4.0"
       val scalatest: String          = "3.0.8"
-      val skeuomorph: String         = "0.0.20-SNAPSHOT"
+      val skeuomorph: String         = "0.0.20"
       val slf4j: String              = "1.7.30"
     }
 

--- a/project/ProjectPlugin.scala
+++ b/project/ProjectPlugin.scala
@@ -59,7 +59,7 @@ object ProjectPlugin extends AutoPlugin {
       val scalacheckToolbox: String  = "0.3.1"
       val scalamock: String          = "4.4.0"
       val scalatest: String          = "3.0.8"
-      val skeuomorph: String         = "0.0.19"
+      val skeuomorph: String         = "0.0.20-SNAPSHOT"
       val slf4j: String              = "1.7.30"
     }
 


### PR DESCRIPTION
## What this does?

Bump the skeuomorph dependency and use its new scalameta-based printer for source code generation.

## Checklist

- [ ] Reviewed the diff to look for typos, println and format errors.
- [ ] Updated the docs accordingly.

