### PR TITLE
Upgrade sbt-org-policies and use bundled releases

### DIFF
--- a/project/ProjectPlugin.scala
+++ b/project/ProjectPlugin.scala
@@ -283,7 +283,7 @@ object ProjectPlugin extends AutoPlugin {
       // Custom release process for the plugin:
       releaseProcess := Seq[ReleaseStep](
         releaseStepCommandAndRemaining("^ publishSigned"),
-        ReleaseStep(action = "sonatypeReleaseAll" :: _)
+        releaseStepCommand("sonatypeBundleRelease")
       )
     )
 
@@ -375,7 +375,7 @@ object ProjectPlugin extends AutoPlugin {
         orgTagRelease,
         orgUpdateChangeLog,
         releaseStepCommandAndRemaining("publishSigned"),
-        releaseStepCommand("sonatypeReleaseAll"),
+        releaseStepCommand("sonatypeBundleRelease"),
         setNextVersion,
         orgCommitNextVersion,
         orgPostRelease

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,6 +1,6 @@
 resolvers += Resolver.sonatypeRepo("releases")
 
-addSbtPlugin("com.47deg"          % "sbt-org-policies" % "0.12.0-M3")
+addSbtPlugin("com.47deg"          % "sbt-org-policies" % "0.12.1")
 addSbtPlugin("com.47deg"          % "sbt-microsites"   % "1.1.0")
 addSbtPlugin("com.eed3si9n"       % "sbt-buildinfo"    % "0.9.0")
 addSbtPlugin("pl.project13.scala" % "sbt-jmh"          % "0.3.7")


### PR DESCRIPTION
Sonatype bundle releases should work with this version of sbt-org-policies, because it brings in a transitive dependency on sbt-sonatype v3.8.1.

Using bundled releases means our artifacts will upload to Sonatype more quickly.

## What this does?
_Changes, features, fixes ..._

## Checklist

- [ ] Reviewed the diff to look for typos, println and format errors.
- [ ] Updated the docs accordingly.

