### PR TITLE
Updates to scalatest 3.1.0

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -434,7 +434,12 @@ lazy val `seed-client-process` = project
   .settings(coverageEnabled := false)
   .settings(noPublishSettings)
   .settings(exampleSeedLogSettings)
-  .dependsOn(netty, fs2, `seed-client-common`, `seed-server-protocol-avro`, `seed-server-protocol-proto`)
+  .dependsOn(
+    netty,
+    fs2,
+    `seed-client-common`,
+    `seed-server-protocol-avro`,
+    `seed-server-protocol-proto`)
 
 lazy val `seed-client-app` = project
   .in(file("modules/examples/seed/client/modules/app"))

--- a/modules/client-cache/src/test/scala/higherkindness/mu/rpc/channel/cache/ClientCacheTests.scala
+++ b/modules/client-cache/src/test/scala/higherkindness/mu/rpc/channel/cache/ClientCacheTests.scala
@@ -23,11 +23,12 @@ import cats.effect.concurrent.Ref
 import cats.implicits._
 import fs2.Stream
 import higherkindness.mu.rpc.common.util.FakeClock
-import org.scalatest.{Matchers, WordSpec}
 
 import scala.concurrent.duration._
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
 
-class ClientCacheTests extends WordSpec with Matchers {
+class ClientCacheTests extends AnyWordSpec with Matchers {
 
   val EC: scala.concurrent.ExecutionContext =
     scala.concurrent.ExecutionContext.Implicits.global

--- a/modules/common/src/test/scala/higherkindness/mu/rpc/common/RpcBaseTestSuite.scala
+++ b/modules/common/src/test/scala/higherkindness/mu/rpc/common/RpcBaseTestSuite.scala
@@ -23,8 +23,10 @@ import org.scalamock.scalatest.MockFactory
 import org.scalatest._
 import scala.compat.Platform
 import scala.io._
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
 
-trait RpcBaseTestSuite extends WordSpec with Matchers with OneInstancePerTest with MockFactory {
+trait RpcBaseTestSuite extends AnyWordSpec with Matchers with OneInstancePerTest with MockFactory {
 
   trait Helpers {
 

--- a/modules/health-check-unary/src/test/scala/higherkindness/mu/rpc/healthcheck/unary/HealthServiceUnaryTest.scala
+++ b/modules/health-check-unary/src/test/scala/higherkindness/mu/rpc/healthcheck/unary/HealthServiceUnaryTest.scala
@@ -19,9 +19,10 @@ package higherkindness.mu.rpc.healthcheck.unary
 import cats.effect.IO
 import higherkindness.mu.rpc.healthcheck.unary.handler._
 import higherkindness.mu.rpc.protocol.Empty
-import org.scalatest.{Matchers, WordSpec}
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
 
-class HealthServiceUnaryTest extends WordSpec with Matchers {
+class HealthServiceUnaryTest extends AnyWordSpec with Matchers {
 
   "Unary health check service" should {
 

--- a/modules/health-check-unary/src/test/scala/higherkindness/mu/rpc/healthcheck/unary/OrderingTest.scala
+++ b/modules/health-check-unary/src/test/scala/higherkindness/mu/rpc/healthcheck/unary/OrderingTest.scala
@@ -16,11 +16,12 @@
 
 package higherkindness.mu.rpc.healthcheck.unary
 
-import org.scalatest.{Matchers, WordSpec}
 import higherkindness.mu.rpc.healthcheck.ordering._
 import higherkindness.mu.rpc.healthcheck.unary.handler.HealthCheck
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
 
-class OrderingTest extends WordSpec with Matchers {
+class OrderingTest extends AnyWordSpec with Matchers {
   "Ordering" should {
     "work" in {
       assert(new HealthCheck("example") === new HealthCheck("example"))

--- a/modules/internal/src/test/scala/higherkindness/mu/rpc/internal/util/BigDecimalUtilTests.scala
+++ b/modules/internal/src/test/scala/higherkindness/mu/rpc/internal/util/BigDecimalUtilTests.scala
@@ -23,8 +23,10 @@ import org.scalacheck.{Arbitrary, Gen}
 import org.scalatest._
 import org.scalacheck.Prop._
 import org.scalatestplus.scalacheck.Checkers
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
 
-class BigDecimalUtilTests extends WordSpec with Matchers with Checkers {
+class BigDecimalUtilTests extends AnyWordSpec with Matchers with Checkers {
 
   def checkAll[T](f: T => BigDecimal)(implicit N: Numeric[T], C: Choose[T]): Assertion = {
     implicit val bigDecimalArbitrary: Arbitrary[BigDecimal] =

--- a/modules/internal/src/test/scala/higherkindness/mu/rpc/internal/util/EncoderUtilTest.scala
+++ b/modules/internal/src/test/scala/higherkindness/mu/rpc/internal/util/EncoderUtilTest.scala
@@ -21,8 +21,10 @@ package util
 import org.scalatest._
 import org.scalacheck.Prop._
 import org.scalatestplus.scalacheck.Checkers
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
 
-class EncoderUtilTest extends WordSpec with Matchers with Checkers {
+class EncoderUtilTest extends AnyWordSpec with Matchers with Checkers {
 
   "EncoderUtil" should {
 

--- a/modules/internal/src/test/scala/higherkindness/mu/rpc/internal/util/JavaTimeUtilTests.scala
+++ b/modules/internal/src/test/scala/higherkindness/mu/rpc/internal/util/JavaTimeUtilTests.scala
@@ -25,8 +25,10 @@ import com.fortysevendeg.scalacheck.datetime.GenDateTime._
 import org.scalatest._
 import org.scalacheck.Prop._
 import org.scalatestplus.scalacheck.Checkers
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
 
-class JavaTimeUtilTests extends WordSpec with Matchers with Checkers {
+class JavaTimeUtilTests extends AnyWordSpec with Matchers with Checkers {
 
   val from: ZonedDateTime = ZonedDateTime.of(1970, 1, 1, 0, 0, 0, 0, ZoneOffset.UTC)
   val range: Duration     = Duration.ofDays(365 * 200)

--- a/modules/kafka/src/test/scala/higherkindness/mu/rpc/kafka/ServiceSpec.scala
+++ b/modules/kafka/src/test/scala/higherkindness/mu/rpc/kafka/ServiceSpec.scala
@@ -29,8 +29,10 @@ import org.scalatest._
 import scala.concurrent.ExecutionContext
 
 import kafkaManagementService._
+import org.scalatest.funsuite.AnyFunSuite
+import org.scalatest.matchers.should.Matchers
 
-class ServiceSpec extends FunSuite with Matchers with OneInstancePerTest with EmbeddedKafka {
+class ServiceSpec extends AnyFunSuite with Matchers with OneInstancePerTest with EmbeddedKafka {
   implicit val cs: ContextShift[IO] = IO.contextShift(ExecutionContext.Implicits.global)
 
   def adminClientSettings[F[_]: Sync](config: EmbeddedKafkaConfig): AdminClientSettings[F] =

--- a/modules/marshallers/jodatime/src/test/scala/higherkindness/mu/rpc/internal/util/JodaTimeUtilTest.scala
+++ b/modules/marshallers/jodatime/src/test/scala/higherkindness/mu/rpc/internal/util/JodaTimeUtilTest.scala
@@ -25,8 +25,10 @@ import higherkindness.mu.rpc.jodatime.util.JodaTimeUtil
 import org.scalatest._
 import org.scalacheck.Prop._
 import org.scalatestplus.scalacheck.Checkers
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
 
-class JodaTimeUtilTest extends WordSpec with Matchers with Checkers {
+class JodaTimeUtilTest extends AnyWordSpec with Matchers with Checkers {
 
   val from: DateTime = new DateTime(1970, 1, 1, 0, 0, 0, 0, DateTimeZone.UTC)
 

--- a/modules/srcgen/core/src/test/scala/higherkindness/mu/rpc/srcgen/OpenApiSrcGenTests.scala
+++ b/modules/srcgen/core/src/test/scala/higherkindness/mu/rpc/srcgen/OpenApiSrcGenTests.scala
@@ -16,14 +16,16 @@
 
 package higherkindness.mu.rpc.srcgen
 
-import org.scalatest.{FlatSpec, Matchers, OptionValues}
-import Matchers._
+import org.scalatest.OptionValues
 import java.io.File
 
 import higherkindness.mu.rpc.srcgen.openapi.OpenApiSrcGenerator
 import higherkindness.mu.rpc.srcgen.openapi.OpenApiSrcGenerator.HttpImpl
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+import Matchers._
 
-class OpenApiSrcGenTests extends FlatSpec with OptionValues {
+class OpenApiSrcGenTests extends AnyFlatSpec with OptionValues {
   val module: String       = new java.io.File(".").getCanonicalPath
   val resourcesFiles: File = new File(module + "/src/test/resources/")
   val openApiFile          = new File(resourcesFiles.getPath() ++ "/openapi/bookstore/book.yaml")

--- a/modules/streaming/fs2/src/test/scala/higherkindness/mu/rpc/healthcheck/fs2/HealthCheckFS2Test.scala
+++ b/modules/streaming/fs2/src/test/scala/higherkindness/mu/rpc/healthcheck/fs2/HealthCheckFS2Test.scala
@@ -19,9 +19,10 @@ package higherkindness.mu.rpc.healthcheck.fs2
 import cats.effect.IO
 import higherkindness.mu.rpc.healthcheck.fs2.handler.HealthServiceFS2
 import higherkindness.mu.rpc.healthcheck.unary.handler.{HealthCheck, HealthStatus, ServerStatus}
-import org.scalatest.{Matchers, WordSpec}
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
 
-class HealthCheckFS2Test extends WordSpec with Matchers {
+class HealthCheckFS2Test extends AnyWordSpec with Matchers {
 
   "FS2 health check service" should {
 

--- a/modules/streaming/monix/src/test/scala/higherkindness/mu/rpc/healthcheck/monix/HealthCheckMonixTest.scala
+++ b/modules/streaming/monix/src/test/scala/higherkindness/mu/rpc/healthcheck/monix/HealthCheckMonixTest.scala
@@ -19,9 +19,10 @@ package higherkindness.mu.rpc.healthcheck.monix
 import cats.effect.IO
 import higherkindness.mu.rpc.healthcheck.monix.handler.HealthServiceMonix
 import higherkindness.mu.rpc.healthcheck.unary.handler.{HealthCheck, HealthStatus, ServerStatus}
-import org.scalatest.{Matchers, WordSpec}
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
 
-class HealthCheckMonixTest extends WordSpec with Matchers {
+class HealthCheckMonixTest extends AnyWordSpec with Matchers {
 
   "Monix health check service" should {
 

--- a/modules/testing/src/test/scala/higherkindness/mu/rpc/testing/MethodsTests.scala
+++ b/modules/testing/src/test/scala/higherkindness/mu/rpc/testing/MethodsTests.scala
@@ -21,8 +21,10 @@ import org.scalacheck.Gen
 import org.scalatest._
 import org.scalatestplus.scalacheck.Checkers
 import org.scalacheck.Prop._
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
 
-class MethodsTests extends WordSpec with Matchers with Checkers {
+class MethodsTests extends AnyWordSpec with Matchers with Checkers {
 
   "methods.voidMethod" should {
 

--- a/modules/testing/src/test/scala/higherkindness/mu/rpc/testing/ServersTests.scala
+++ b/modules/testing/src/test/scala/higherkindness/mu/rpc/testing/ServersTests.scala
@@ -23,8 +23,10 @@ import org.scalatestplus.scalacheck.Checkers
 import org.scalacheck.Prop._
 
 import scala.collection.JavaConverters._
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
 
-class ServersTests extends WordSpec with Matchers with Checkers {
+class ServersTests extends AnyWordSpec with Matchers with Checkers {
 
   import TestingUtils._
 

--- a/project/ProjectPlugin.scala
+++ b/project/ProjectPlugin.scala
@@ -320,7 +320,10 @@ object ProjectPlugin extends AutoPlugin {
     )
 
     lazy val docsSettings: Seq[Def.Setting[_]] = Seq(
-      libraryDependencies += %%("scalatest", V.scalatest),
+      libraryDependencies ++= Seq(
+        %%("scalatest", V.scalatest),
+        "org.scalatestplus" %% "scalatestplus-scalacheck" % V.scalatestplusScheck
+      ),
       scalacOptions in Tut ~= (_ filterNot Set("-Ywarn-unused-import", "-Xlint").contains)
     )
 

--- a/project/ProjectPlugin.scala
+++ b/project/ProjectPlugin.scala
@@ -58,7 +58,8 @@ object ProjectPlugin extends AutoPlugin {
       val scalacheck: String         = "1.14.3"
       val scalacheckToolbox: String  = "0.3.1"
       val scalamock: String          = "4.4.0"
-      val scalatest: String          = "3.0.8"
+      val scalatest: String          = "3.1.0"
+      val scalatestplusScheck        = "3.1.0.0-RC2"
       val skeuomorph: String         = "0.0.20"
       val slf4j: String              = "1.7.30"
     }
@@ -67,7 +68,8 @@ object ProjectPlugin extends AutoPlugin {
       libraryDependencies ++= Seq(
         %%("cats-effect", V.catsEffect)                  % Test,
         %%("scalamock", V.scalamock)                     % Test,
-        %%("scheckToolboxDatetime", V.scalacheckToolbox) % Test
+        %%("scheckToolboxDatetime", V.scalacheckToolbox) % Test,
+        "org.scalatestplus" %% "scalatestplus-scalacheck" % V.scalatestplusScheck % Test
       )
     )
 
@@ -195,7 +197,8 @@ object ProjectPlugin extends AutoPlugin {
       libraryDependencies ++= Seq(
         %("grpc-testing", V.grpc),
         %%("cats-effect", V.catsEffect),
-        %%("scalacheck", V.scalacheck) % Test
+        %%("scalacheck", V.scalacheck) % Test,
+        "org.scalatestplus" %% "scalatestplus-scalacheck" % V.scalatestplusScheck % Test
       )
     )
 

--- a/project/ProjectPlugin.scala
+++ b/project/ProjectPlugin.scala
@@ -26,42 +26,42 @@ object ProjectPlugin extends AutoPlugin {
   object autoImport {
 
     lazy val V = new {
-      val avro4s: String             = "1.8.4"
-      val avrohugger: String         = "1.0.0-RC22"
-      val betterMonadicFor: String   = "0.3.1"
-      val catsEffect: String         = "2.0.0"
-      val circe: String              = "0.12.3"
-      val dropwizard: String         = "4.1.2"
-      val embeddedKafka: String      = "2.4.0"
-      val enumeratum: String         = "1.5.15"
-      val frees: String              = "0.8.2"
-      val fs2: String                = "2.2.1"
-      val fs2Grpc: String            = "0.6.0"
-      val fs2Kafka: String           = "0.20.2"
-      val grpc: String               = "1.24.2"
-      val jodaTime: String           = "2.10.5"
-      val http4s: String             = "0.21.0-M6"
-      val kindProjector: String      = "0.10.3"
-      val log4cats: String           = "1.0.1"
-      val log4s: String              = "1.8.2"
-      val logback: String            = "1.2.3"
-      val monix: String              = "3.1.0"
-      val monocle: String            = "2.0.1"
-      val nettySSL: String           = "2.0.25.Final"
-      val paradise: String           = "2.1.1"
-      val pbdirect: String           = "0.4.1"
-      val prometheus: String         = "0.8.1"
-      val pureconfig: String         = "0.12.2"
-      val reactiveStreams: String    = "1.0.3"
-      val scala: String              = "2.12.10"
-      val scopt: String              = "3.7.1"
-      val scalacheck: String         = "1.14.3"
-      val scalacheckToolbox: String  = "0.3.1"
-      val scalamock: String          = "4.4.0"
-      val scalatest: String          = "3.1.0"
-      val scalatestplusScheck        = "3.1.0.0-RC2"
-      val skeuomorph: String         = "0.0.20"
-      val slf4j: String              = "1.7.30"
+      val avro4s: String              = "1.8.4"
+      val avrohugger: String          = "1.0.0-RC22"
+      val betterMonadicFor: String    = "0.3.1"
+      val catsEffect: String          = "2.0.0"
+      val circe: String               = "0.12.3"
+      val dropwizard: String          = "4.1.2"
+      val embeddedKafka: String       = "2.4.0"
+      val enumeratum: String          = "1.5.15"
+      val frees: String               = "0.8.2"
+      val fs2: String                 = "2.2.1"
+      val fs2Grpc: String             = "0.6.0"
+      val fs2Kafka: String            = "0.20.2"
+      val grpc: String                = "1.24.2"
+      val jodaTime: String            = "2.10.5"
+      val http4s: String              = "0.21.0-M6"
+      val kindProjector: String       = "0.10.3"
+      val log4cats: String            = "1.0.1"
+      val log4s: String               = "1.8.2"
+      val logback: String             = "1.2.3"
+      val monix: String               = "3.1.0"
+      val monocle: String             = "2.0.1"
+      val nettySSL: String            = "2.0.25.Final"
+      val paradise: String            = "2.1.1"
+      val pbdirect: String            = "0.4.1"
+      val prometheus: String          = "0.8.1"
+      val pureconfig: String          = "0.12.2"
+      val reactiveStreams: String     = "1.0.3"
+      val scala: String               = "2.12.10"
+      val scopt: String               = "3.7.1"
+      val scalacheck: String          = "1.14.3"
+      val scalacheckToolbox: String   = "0.3.1"
+      val scalamock: String           = "4.4.0"
+      val scalatest: String           = "3.1.0"
+      val scalatestplusScheck: String = "3.1.0.0-RC2"
+      val skeuomorph: String          = "0.0.20"
+      val slf4j: String               = "1.7.30"
     }
 
     lazy val commonSettings: Seq[Def.Setting[_]] = Seq(
@@ -69,7 +69,7 @@ object ProjectPlugin extends AutoPlugin {
         %%("cats-effect", V.catsEffect)                  % Test,
         %%("scalamock", V.scalamock)                     % Test,
         %%("scheckToolboxDatetime", V.scalacheckToolbox) % Test,
-        "org.scalatestplus" %% "scalatestplus-scalacheck" % V.scalatestplusScheck % Test
+        "org.scalatestplus"                              %% "scalatestplus-scalacheck" % V.scalatestplusScheck % Test
       )
     )
 
@@ -77,7 +77,7 @@ object ProjectPlugin extends AutoPlugin {
       libraryDependencies ++= Seq(
         %%("cats-effect", V.catsEffect),
         %("grpc-stub", V.grpc),
-        "com.47deg" %% "pbdirect" % V.pbdirect,
+        "com.47deg"    %% "pbdirect"   % V.pbdirect,
         "com.beachape" %% "enumeratum" % V.enumeratum,
         %%("avro4s", V.avro4s),
         %%("log4s", V.log4s),
@@ -198,7 +198,7 @@ object ProjectPlugin extends AutoPlugin {
         %("grpc-testing", V.grpc),
         %%("cats-effect", V.catsEffect),
         %%("scalacheck", V.scalacheck) % Test,
-        "org.scalatestplus" %% "scalatestplus-scalacheck" % V.scalatestplusScheck % Test
+        "org.scalatestplus"            %% "scalatestplus-scalacheck" % V.scalatestplusScheck % Test
       )
     )
 
@@ -219,7 +219,7 @@ object ProjectPlugin extends AutoPlugin {
 
     lazy val kafkaSettings: Seq[Def.Setting[_]] = Seq(
       libraryDependencies ++= Seq(
-        "com.ovoenergy" %% "fs2-kafka" % V.fs2Kafka,
+        "com.ovoenergy"           %% "fs2-kafka"      % V.fs2Kafka,
         "io.github.embeddedkafka" %% "embedded-kafka" % V.embeddedKafka % Test
       )
     )


### PR DESCRIPTION
## What this does?

This PR updates to Scalatest 3.1.0, adding the new `scalatestplus-scalacheck` dependency, as it's needed from now on.

## Checklist

- [x] Reviewed the diff to look for typos, println and format errors.
- [ ] Updated the docs accordingly.

