### PR TITLE
Upgrade to avro4s 3.0.x

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -620,7 +620,7 @@ lazy val root = project
 
 lazy val docs = project
   .in(file("docs"))
-  .dependsOn(allModulesDeps: _*)
+  .dependsOn(allModulesDeps.filterNot(_.project == LocalProject("benchmarks-vprev")): _*)
   .settings(name := "mu-docs")
   .settings(docsSettings: _*)
   .settings(micrositeSettings: _*)

--- a/docs/src/main/docs/core-concepts.md
+++ b/docs/src/main/docs/core-concepts.md
@@ -327,7 +327,7 @@ object protocol3 {
 }
 ```
 
-For `Avro` the process is quite similar, but in this case we need to provide three instances of [Avro4s]. `ToSchema`, `FromValue`, and `ToValue`.
+For `Avro` the process is quite similar, but in this case we need to provide three instances of three [Avro4s] type classes: `SchemaFor`, `Encoder`, and `Decoder`.
 
 ```scala mdoc:silent
 object protocol4 {
@@ -339,18 +339,18 @@ object protocol4 {
   import org.apache.avro.Schema
   import org.apache.avro.Schema.Field
 
-  implicit object LocalDateToSchema extends ToSchema[LocalDate] {
-    override val schema: Schema =
+  implicit object LocalDateSchemaFor extends SchemaFor[LocalDate] {
+    override def schema(fm: com.sksamuel.avro4s.FieldMapper): Schema =
       Schema.create(Schema.Type.STRING)
   }
 
-  implicit object LocalDateToValue extends ToValue[LocalDate] {
-    override def apply(value: LocalDate): String =
+  implicit object LocalDateEncoder extends Encoder[LocalDate] {
+    override def encode(value: LocalDate, schema: Schema, fm: FieldMapper): String =
       value.format(DateTimeFormatter.ISO_LOCAL_DATE)
   }
 
-  implicit object LocalDateFromValue extends FromValue[LocalDate] {
-    override def apply(value: Any, field: Field): LocalDate =
+  implicit object LocalDateDecoder extends Decoder[LocalDate] {
+    override def decode(value: Any, schema: Schema, fm: FieldMapper): LocalDate =
       LocalDate.parse(value.toString(), DateTimeFormatter.ISO_LOCAL_DATE)
   }
 

--- a/docs/src/main/docs/core-concepts.md
+++ b/docs/src/main/docs/core-concepts.md
@@ -370,13 +370,13 @@ object protocol4 {
 
 * `BigDecimal` in `Protobuf`
   * `import higherkindness.mu.rpc.internal.encoders.pbd.bigDecimal._`
-* `java.time.LocalDate` and `java.time.LocalDateTime` in `Protobuf`
+* `java.time.LocalDate`, `java.time.LocalDateTime` and `java.time.Instant` in `Protobuf`
   * `import higherkindness.mu.rpc.internal.encoders.pbd.javatime._`
 * `BigDecimal` in `Avro` (**note**: this encoder is not avro spec compliant)
   * `import higherkindness.mu.rpc.internal.encoders.avro.bigdecimal._`
 * Tagged `BigDecimal` in `Avro`
   * `import higherkindness.mu.rpc.internal.encoders.avro.bigDecimalTagged._`
-* `java.time.LocalDate` and `java.time.LocalDateTime` in `Avro`
+* `java.time.LocalDateTime` in `Avro`
   * `import higherkindness.mu.rpc.internal.encoders.avro.javatime._`
 
 Mu also provides instances for `org.joda.time.LocalDate` and `org.joda.time.LocalDateTime`, but you need the `mu-rpc-marshallers-jodatime` extra dependency. See the [main section](/mu/scala/) for the SBT instructions.
@@ -386,12 +386,12 @@ Mu also provides instances for `org.joda.time.LocalDate` and `org.joda.time.Loca
 * `org.joda.time.LocalDate` and `org.joda.time.LocalDateTime` in `Avro`
   * `import higherkindness.mu.rpc.marshallers.jodaTimeEncoders.avro._`
 
-**Note**: If you want to send one of these instances directly as a request or response through Avro, you need to provide an instance of `Marshaller`. [Mu] provides the marshallers for `BigDecimal`, `java.time.LocalDate`, `java.time.LocalDateTime`, `org.joda.time.LocalDate` and `org.joda.time.LocalDateTime` in a separate package:
+**Note**: If you want to send one of these instances directly as a request or response through Avro, you need to provide an instance of `Marshaller`. [Mu] provides the marshallers for `BigDecimal`, `java.time.LocalDate`, `java.time.LocalDateTime`, `java.time.Instant`, `org.joda.time.LocalDate` and `org.joda.time.LocalDateTime` in a separate package:
 * `BigDecimal` in `Avro`
   * `import higherkindness.mu.rpc.internal.encoders.avro.bigdecimal.marshallers._`
 * Tagged `BigDecimal` in `Avro` (**note**: this encoder is not avro spec compliant)
   * `import higherkindness.mu.rpc.internal.encoders.avro.bigDecimalTagged.marshallers._`
-* `java.time.LocalDate` and `java.time.LocalDateTime` in `Avro`
+* `java.time.LocalDate`, `java.time.LocalDateTime` and `java.time.Instant` in `Avro`
   * `import higherkindness.mu.rpc.internal.encoders.avro.javatime.marshallers._`
 * `org.joda.time.LocalDate` and `org.joda.time.LocalDateTime` in `Avro`
   * `import higherkindness.mu.rpc.marshallers.jodaTimeEncoders.avro.marshallers._`

--- a/modules/common/src/test/scala/higherkindness/mu/rpc/common/RpcBaseTestSuite.scala
+++ b/modules/common/src/test/scala/higherkindness/mu/rpc/common/RpcBaseTestSuite.scala
@@ -37,7 +37,9 @@ trait RpcBaseTestSuite extends AnyWordSpec with Matchers with OneInstancePerTest
 
   implicit val prettifier: Prettifier = Prettifier {
     case x => // includes null
-      Platform.EOL + Prettifier.default(x) // initial linebreak makes expected/actual results line up nicely
+      Platform.EOL + Prettifier.default(
+        x
+      ) // initial linebreak makes expected/actual results line up nicely
   }
 
   // delegating the check to a def gets its name used in the cancellation message (cleaner than the boolean comparison result)

--- a/modules/examples/seed/server/modules/protocol_avro/src/main/scala/People.scala
+++ b/modules/examples/seed/server/modules/protocol_avro/src/main/scala/People.scala
@@ -16,20 +16,18 @@
 
 package example.seed.server.protocol.avro
 
-import higherkindness.mu.rpc.protocol._
-
 import shapeless.{:+:, CNil}
 
 sealed trait People extends Product with Serializable
 
-@message final case class Person(name: String, age: Int) extends People
+final case class Person(name: String, age: Int) extends People
 
-@message final case class NotFoundError(message: String) extends People
+final case class NotFoundError(message: String) extends People
 
-@message final case class DuplicatedPersonError(message: String) extends People
+final case class DuplicatedPersonError(message: String) extends People
 
-@message final case class PeopleRequest(name: String) extends People
+final case class PeopleRequest(name: String) extends People
 
-@message final case class PeopleResponse(
+final case class PeopleResponse(
     result: Person :+: NotFoundError :+: DuplicatedPersonError :+: CNil
 ) extends People

--- a/modules/examples/todolist/protocol/src/main/scala/TodoListProtocol.scala
+++ b/modules/examples/todolist/protocol/src/main/scala/TodoListProtocol.scala
@@ -21,13 +21,13 @@ import higherkindness.mu.rpc.protocol._
 
 trait TodoListProtocol {
 
-  final case class TodoListMessage(title: String, tagId: Int, id: Int)
+  case class TodoListMessage(title: String, tagId: Int, id: Int)
 
-  final case class TodoListRequest(title: String, tagId: Int)
+  case class TodoListRequest(title: String, tagId: Int)
 
-  final case class TodoListList(list: List[TodoListMessage])
+  case class TodoListList(list: List[TodoListMessage])
 
-  final case class TodoListResponse(msg: Option[TodoListMessage])
+  case class TodoListResponse(msg: Option[TodoListMessage])
 
   @service(Avro)
   trait TodoListRpcService[F[_]] {

--- a/modules/legacy-avro-decimal/encoders/src/main/scala/higherkindness/mu/rpc/protocol/legacy/avro.scala
+++ b/modules/legacy-avro-decimal/encoders/src/main/scala/higherkindness/mu/rpc/protocol/legacy/avro.scala
@@ -20,27 +20,26 @@ import java.io.{ByteArrayInputStream, InputStream}
 import java.nio.ByteBuffer
 
 import com.google.common.io.ByteStreams
-import com.sksamuel.avro4s.{FromValue, ToSchema, ToValue}
+import com.sksamuel.avro4s.{Decoder, Encoder, FieldMapper, SchemaFor}
 import higherkindness.mu.rpc.internal.util.BigDecimalUtil
 import io.grpc.MethodDescriptor.Marshaller
 import org.apache.avro.Schema
-import org.apache.avro.Schema.Field
 
 object avro {
 
   import AvroDecimalCompatUtils._
 
-  implicit object bigDecimalToSchema extends ToSchema[AvroDecimalCompat] {
-    override val schema: Schema = Schema.create(Schema.Type.BYTES)
+  implicit object bigDecimalSchemaFor extends SchemaFor[AvroDecimalCompat] {
+    def schema(fm: FieldMapper): Schema = Schema.create(Schema.Type.BYTES)
   }
 
-  implicit object bigDecimalFromValue extends FromValue[AvroDecimalCompat] {
-    def apply(value: Any, field: Field): AvroDecimalCompat =
+  implicit object bigDecimalDecoder extends Decoder[AvroDecimalCompat] {
+    def decode(value: Any, schema: Schema, fm: FieldMapper): AvroDecimalCompat =
       AvroDecimalCompat(BigDecimalUtil.byteToBigDecimal(value.asInstanceOf[ByteBuffer].array()))
   }
 
-  implicit object bigDecimalToValue extends ToValue[AvroDecimalCompat] {
-    override def apply(value: AvroDecimalCompat): ByteBuffer =
+  implicit object bigDecimalEncoder extends Encoder[AvroDecimalCompat] {
+    def encode(value: AvroDecimalCompat, schema: Schema, fm: FieldMapper): ByteBuffer =
       ByteBuffer.wrap(BigDecimalUtil.bigDecimalToByte(value.toBigDecimal))
   }
 

--- a/modules/marshallers/jodatime/src/main/scala/higherkindness/mu/rpc/marshallers/jodaTimeEncoders.scala
+++ b/modules/marshallers/jodatime/src/main/scala/higherkindness/mu/rpc/marshallers/jodaTimeEncoders.scala
@@ -26,7 +26,6 @@ import higherkindness.mu.rpc.internal.util.EncoderUtil
 import higherkindness.mu.rpc.jodatime.util.JodaTimeUtil
 import io.grpc.MethodDescriptor.Marshaller
 import org.apache.avro.Schema
-import org.apache.avro.Schema.Field
 import org.joda.time.{LocalDate, LocalDateTime}
 
 object jodaTimeEncoders {
@@ -53,34 +52,27 @@ object jodaTimeEncoders {
 
     import com.sksamuel.avro4s._
 
-    implicit object JodaLocalDateToSchema extends ToSchema[LocalDate] {
-      override val schema: Schema = Schema.create(Schema.Type.INT)
+    implicit object JodaLocalDateSchemaFor extends SchemaFor[LocalDate] {
+      override def schema(fm: FieldMapper): Schema = Schema.create(Schema.Type.INT)
     }
 
-    implicit object JodaLocalDateFromValue extends FromValue[LocalDate] {
-      override def apply(value: Any, field: Field): LocalDate =
-        JodaTimeUtil.intToJodaLocalDate(value.asInstanceOf[Int])
+    implicit val JodaLocalDateDecoder: Decoder[LocalDate] =
+      Decoder[Int].map(JodaTimeUtil.intToJodaLocalDate)
+
+    implicit val JodaLocalDateEncoder: Encoder[LocalDate] =
+      Encoder[Int].comap(JodaTimeUtil.jodaLocalDateToInt)
+
+    implicit object JodaLocalDateTimeSchemaFor extends SchemaFor[LocalDateTime] {
+      override def schema(fm: FieldMapper): Schema = Schema.create(Schema.Type.LONG)
     }
 
-    implicit object JodalocalDateToValue extends ToValue[LocalDate] {
-      override def apply(value: LocalDate): Int =
-        JodaTimeUtil.jodaLocalDateToInt(value)
-    }
+    implicit val JodaLocalDateTimeDecoder: Decoder[LocalDateTime] =
+      Decoder[Long].map(JodaTimeUtil.longToJodaLocalDateTime)
 
-    implicit object JodaLocalDateTimeToSchema extends ToSchema[LocalDateTime] {
-      override val schema: Schema = Schema.create(Schema.Type.LONG)
-    }
+    implicit val JodaLocalDateTimeEncoder: Encoder[LocalDateTime] =
+      Encoder[Long].comap(JodaTimeUtil.jodaLocalDateTimeToLong)
 
-    implicit object JodaLocalDateTimeFromValue extends FromValue[LocalDateTime] {
-      def apply(value: Any, field: Field): LocalDateTime =
-        JodaTimeUtil.longToJodaLocalDateTime(value.asInstanceOf[Long])
-    }
-
-    implicit object JodaLocalDateTimeToValue extends ToValue[LocalDateTime] {
-      override def apply(value: LocalDateTime): Long =
-        JodaTimeUtil.jodaLocalDateTimeToLong(value)
-    }
-
+    //
     /*
      * These marshallers are only used when the entire gRPC request/response
      * is a LocalDate/LocalDateTime. When a LocalDate/LocalDateTime is a field

--- a/modules/marshallers/jodatime/src/main/scala/higherkindness/mu/rpc/marshallers/jodaTimeEncoders.scala
+++ b/modules/marshallers/jodatime/src/main/scala/higherkindness/mu/rpc/marshallers/jodaTimeEncoders.scala
@@ -72,7 +72,6 @@ object jodaTimeEncoders {
     implicit val JodaLocalDateTimeEncoder: Encoder[LocalDateTime] =
       Encoder[Long].comap(JodaTimeUtil.jodaLocalDateTimeToLong)
 
-    //
     /*
      * These marshallers are only used when the entire gRPC request/response
      * is a LocalDate/LocalDateTime. When a LocalDate/LocalDateTime is a field

--- a/modules/server/src/test/scala/higherkindness/mu/rpc/avro/RPCTests.scala
+++ b/modules/server/src/test/scala/higherkindness/mu/rpc/avro/RPCTests.scala
@@ -194,7 +194,7 @@ class RPCTests extends RpcBaseTestSuite {
       "be able to provide a compatible response within a coproduct" in {
         runSucceedAssertion(
           serviceResponseAddedBooleanCoproduct.RPCService.bindService[ConcurrentMonad],
-          ResponseCoproduct(Coproduct[Response :+: Int :+: String :+: CNil](0))
+          ResponseCoproduct(Coproduct[Int :+: String :+: Response :+: CNil](0))
         )(_.getCoproduct(requestCoproduct(request)))
       }
     }

--- a/modules/server/src/test/scala/higherkindness/mu/rpc/avro/RPCTests.scala
+++ b/modules/server/src/test/scala/higherkindness/mu/rpc/avro/RPCTests.scala
@@ -95,6 +95,8 @@ class RPCTests extends RpcBaseTestSuite {
 
     "remove an item in coproduct, and" should {
       "be able to respond to an outdated request with the previous coproduct" in {
+        pending // waiting for https://github.com/sksamuel/avro4s/pull/439
+
         runSucceedAssertion(
           serviceRequestRemovedCoproductItem.RPCService.bindService[ConcurrentMonad],
           responseCoproduct(response)
@@ -102,6 +104,8 @@ class RPCTests extends RpcBaseTestSuite {
       }
 
       "be able to respond to an outdated request with the removed valued of the previous coproduct" in {
+        pending // waiting for https://github.com/sksamuel/avro4s/pull/439
+
         runSucceedAssertion(
           serviceRequestRemovedCoproductItem.RPCService.bindService[ConcurrentMonad],
           responseCoproduct(response)
@@ -192,6 +196,8 @@ class RPCTests extends RpcBaseTestSuite {
 
     "add a new item in a coproduct, and" should {
       "be able to provide a compatible response within a coproduct" in {
+        pending // waiting for https://github.com/sksamuel/avro4s/pull/439
+
         runSucceedAssertion(
           serviceResponseAddedBooleanCoproduct.RPCService.bindService[ConcurrentMonad],
           ResponseCoproduct(Coproduct[Int :+: String :+: Response :+: CNil](0))

--- a/modules/server/src/test/scala/higherkindness/mu/rpc/avro/RPCTests.scala
+++ b/modules/server/src/test/scala/higherkindness/mu/rpc/avro/RPCTests.scala
@@ -95,8 +95,6 @@ class RPCTests extends RpcBaseTestSuite {
 
     "remove an item in coproduct, and" should {
       "be able to respond to an outdated request with the previous coproduct" in {
-        pending // waiting for https://github.com/sksamuel/avro4s/pull/439
-
         runSucceedAssertion(
           serviceRequestRemovedCoproductItem.RPCService.bindService[ConcurrentMonad],
           responseCoproduct(response)
@@ -104,8 +102,6 @@ class RPCTests extends RpcBaseTestSuite {
       }
 
       "be able to respond to an outdated request with the removed valued of the previous coproduct" in {
-        pending // waiting for https://github.com/sksamuel/avro4s/pull/439
-
         runSucceedAssertion(
           serviceRequestRemovedCoproductItem.RPCService.bindService[ConcurrentMonad],
           responseCoproduct(response)
@@ -196,8 +192,6 @@ class RPCTests extends RpcBaseTestSuite {
 
     "add a new item in a coproduct, and" should {
       "be able to provide a compatible response within a coproduct" in {
-        pending // waiting for https://github.com/sksamuel/avro4s/pull/439
-
         runSucceedAssertion(
           serviceResponseAddedBooleanCoproduct.RPCService.bindService[ConcurrentMonad],
           ResponseCoproduct(Coproduct[Int :+: String :+: Response :+: CNil](0))

--- a/modules/server/src/test/scala/higherkindness/mu/rpc/avro/Utils.scala
+++ b/modules/server/src/test/scala/higherkindness/mu/rpc/avro/Utils.scala
@@ -30,12 +30,12 @@ object Utils extends CommonUtils {
   case class RequestDroppedField(a: String)
   case class RequestReplacedType(a: String, c: Boolean = true)
   case class RequestRenamedField(a: String, c: Int = 0)
-  case class RequestCoproduct[A](a: A :+: Int :+: String :+: CNil)
-  case class RequestSuperCoproduct[A](a: A :+: Int :+: String :+: Boolean :+: CNil)
+  case class RequestCoproduct[A](a: Int :+: String :+: A :+: CNil)
+  case class RequestSuperCoproduct[A](a: Int :+: String :+: Boolean :+: A :+: CNil)
   case class RequestCoproductNoInt[A](
-      b: A :+: String :+: CNil = Coproduct[A :+: String :+: CNil]("")
+      b: String :+: A :+: CNil = Coproduct[String :+: A :+: CNil]("")
   )
-  case class RequestCoproductReplaced[A](a: A :+: Int :+: Boolean :+: CNil)
+  case class RequestCoproductReplaced[A](a: Int :+: Boolean :+: A :+: CNil)
 
   case class Response(a: String, b: Int = 123)
   case class ResponseAddedBoolean(a: String, b: Int, c: Boolean)
@@ -43,19 +43,19 @@ object Utils extends CommonUtils {
   case class ResponseReplacedType(a: String, b: Int = 123, c: Boolean)
   case class ResponseRenamedField(a: String, b: Int = 123, c: Int)
   case class ResponseDroppedField(a: String)
-  case class ResponseCoproduct[A](a: A :+: Int :+: String :+: CNil)
+  case class ResponseCoproduct[A](a: Int :+: String :+: A :+: CNil)
   case class ResponseSuperCoproduct[A](
-      a: A :+: Int :+: String :+: CNil = Coproduct[A :+: Int :+: String :+: CNil](0),
-      b: A :+: Int :+: String :+: Boolean :+: CNil
+      a: Int :+: String :+: A :+: CNil = Coproduct[Int :+: String :+: A :+: CNil](0),
+      b: Int :+: String :+: Boolean :+: A :+: CNil
   )
-  case class ResponseCoproductNoInt[A](a: A :+: String :+: CNil)
-  case class ResponseCoproductReplaced[A](a: A :+: Int :+: Boolean :+: CNil)
+  case class ResponseCoproductNoInt[A](a: String :+: A :+: CNil)
+  case class ResponseCoproductReplaced[A](a: Int :+: Boolean :+: A :+: CNil)
 
   val request                   = Request("foo", 123)
-  def requestCoproduct[A](a: A) = RequestCoproduct(Coproduct[A :+: Int :+: String :+: CNil](a))
-  val requestCoproductInt       = RequestCoproduct(Coproduct[Request :+: Int :+: String :+: CNil](1))
+  def requestCoproduct[A](a: A) = RequestCoproduct(Coproduct[Int :+: String :+: A :+: CNil](a))
+  val requestCoproductInt       = RequestCoproduct(Coproduct[Int :+: String :+: Request :+: CNil](1))
   val requestCoproductString = RequestCoproduct(
-    Coproduct[Request :+: Int :+: String :+: CNil]("hi")
+    Coproduct[Int :+: String :+: Request :+: CNil]("hi")
   )
 
   val response                        = Response("foo", 123)
@@ -63,10 +63,10 @@ object Utils extends CommonUtils {
   val responseReplacedType            = ResponseReplacedType(a = response.a, c = true)
   val responseRenamedField            = ResponseRenamedField(a = response.a, c = 456)
   val responseDroppedField            = ResponseDroppedField(response.a)
-  def responseCoproduct[A](a: A)      = ResponseCoproduct(Coproduct[A :+: Int :+: String :+: CNil](a))
-  def responseCoproductNoInt[A](a: A) = ResponseCoproductNoInt(Coproduct[A :+: String :+: CNil](a))
+  def responseCoproduct[A](a: A)      = ResponseCoproduct(Coproduct[Int :+: String :+: A :+: CNil](a))
+  def responseCoproductNoInt[A](a: A) = ResponseCoproductNoInt(Coproduct[String :+: A :+: CNil](a))
   def responseCoproductReplaced[A](a: A) =
-    ResponseCoproductReplaced(Coproduct[A :+: Int :+: Boolean :+: CNil](a))
+    ResponseCoproductReplaced(Coproduct[Int :+: Boolean :+: A :+: CNil](a))
 
   //Original Service
 
@@ -214,7 +214,7 @@ object Utils extends CommonUtils {
       def get(a: Request): F[Response] = Effect[F].delay(response)
       def getCoproduct(a: RequestCoproduct[Request]): F[ResponseCoproduct[Response]] =
         Effect[F].delay(
-          ResponseCoproduct(Coproduct[Response :+: Int :+: String :+: CNil](response))
+          ResponseCoproduct(Coproduct[Int :+: String :+: Response :+: CNil](response))
         )
     }
 
@@ -285,7 +285,7 @@ object Utils extends CommonUtils {
       def getCoproduct(a: RequestCoproduct[Request]): F[ResponseSuperCoproduct[Response]] =
         Effect[F].delay(
           ResponseSuperCoproduct(
-            b = Coproduct[Response :+: Int :+: String :+: Boolean :+: CNil](true)
+            b = Coproduct[Int :+: String :+: Boolean :+: Response :+: CNil](true)
           )
         )
     }

--- a/modules/server/src/test/scala/higherkindness/mu/rpc/protocol/RPCMethodNameTests.scala
+++ b/modules/server/src/test/scala/higherkindness/mu/rpc/protocol/RPCMethodNameTests.scala
@@ -68,9 +68,7 @@ class RPCMethodNameTests extends RpcBaseTestSuite with BeforeAndAfterAll with Ch
         ProtoRPCServiceDef.clientFromChannel[ConcurrentMonad](_)
       ) { client =>
         check {
-          forAll { s: String =>
-            client.proto(Request(s)).map(_.length).unsafeRunSync() == s.length
-          }
+          forAll { s: String => client.proto(Request(s)).map(_.length).unsafeRunSync() == s.length }
         }
       }
 
@@ -83,9 +81,7 @@ class RPCMethodNameTests extends RpcBaseTestSuite with BeforeAndAfterAll with Ch
         AvroRPCServiceDef.clientFromChannel[ConcurrentMonad](_)
       ) { client =>
         check {
-          forAll { s: String =>
-            client.avro(Request(s)).map(_.length).unsafeRunSync() == s.length
-          }
+          forAll { s: String => client.avro(Request(s)).map(_.length).unsafeRunSync() == s.length }
         }
       }
 

--- a/modules/server/src/test/scala/higherkindness/mu/rpc/protocol/RPCNamespaceTests.scala
+++ b/modules/server/src/test/scala/higherkindness/mu/rpc/protocol/RPCNamespaceTests.scala
@@ -85,9 +85,7 @@ class RPCNamespaceTests extends RpcBaseTestSuite with BeforeAndAfterAll with Che
         AvroRPCServiceDef.clientFromChannel[ConcurrentMonad](_)
       ) { client =>
         check {
-          forAll { s: String =>
-            client.avro(Request(s)).map(_.length).unsafeRunSync() == s.length
-          }
+          forAll { s: String => client.avro(Request(s)).map(_.length).unsafeRunSync() == s.length }
         }
       }
 

--- a/modules/server/src/test/scala/higherkindness/mu/rpc/protocol/RPCTests.scala
+++ b/modules/server/src/test/scala/higherkindness/mu/rpc/protocol/RPCTests.scala
@@ -125,7 +125,9 @@ class RPCTests extends RpcBaseTestSuite with BeforeAndAfterAll {
       clientProgram[ConcurrentMonad]("SRE")
         .unsafeRunSync() shouldBe List(C("INVALID_ARGUMENT: SRE", a1))
       clientProgram[ConcurrentMonad]("RTE")
-        .unsafeRunSync() shouldBe List(C("UNKNOWN", a1)) //todo: consider preserving the exception as is done for unary
+        .unsafeRunSync() shouldBe List(
+        C("UNKNOWN", a1)
+      ) //todo: consider preserving the exception as is done for unary
       clientProgram[ConcurrentMonad]("Thrown")
         .unsafeRunSync() shouldBe List(C("UNKNOWN", a1))
     }

--- a/modules/srcgen/core/src/test/scala/higherkindness/mu/rpc/srcgen/AvroSrcGenTests.scala
+++ b/modules/srcgen/core/src/test/scala/higherkindness/mu/rpc/srcgen/AvroSrcGenTests.scala
@@ -29,9 +29,7 @@ class AvroSrcGenTests extends RpcBaseTestSuite with Checkers {
 
     "generate correct Scala classes" in {
       check {
-        forAll { scenario: Scenario =>
-          test(scenario)
-        }
+        forAll { scenario: Scenario => test(scenario) }
       }
     }
   }

--- a/project/ProjectPlugin.scala
+++ b/project/ProjectPlugin.scala
@@ -26,7 +26,7 @@ object ProjectPlugin extends AutoPlugin {
   object autoImport {
 
     lazy val V = new {
-      val avro4s: String              = "3.0.4"
+      val avro4s: String              = "3.0.6"
       val avrohugger: String          = "1.0.0-RC22"
       val betterMonadicFor: String    = "0.3.1"
       val catsEffect: String          = "2.1.1"

--- a/project/ProjectPlugin.scala
+++ b/project/ProjectPlugin.scala
@@ -26,7 +26,7 @@ object ProjectPlugin extends AutoPlugin {
   object autoImport {
 
     lazy val V = new {
-      val avro4s: String              = "3.0.6"
+      val avro4s: String              = "3.0.7"
       val avrohugger: String          = "1.0.0-RC22"
       val betterMonadicFor: String    = "0.3.1"
       val catsEffect: String          = "2.1.1"

--- a/project/ProjectPlugin.scala
+++ b/project/ProjectPlugin.scala
@@ -26,7 +26,7 @@ object ProjectPlugin extends AutoPlugin {
   object autoImport {
 
     lazy val V = new {
-      val avro4s: String              = "1.8.4"
+      val avro4s: String              = "3.0.4"
       val avrohugger: String          = "1.0.0-RC22"
       val betterMonadicFor: String    = "0.3.1"
       val catsEffect: String          = "2.1.1"


### PR DESCRIPTION
This is mostly mechanical rewrites of the type class instances:

* `ToSchema` -> `SchemaFor`
* `ToValue` -> `Encoder`
* `FromValue` -> `Decoder`

Also slightly rewrote the scale/precision/rounding mode handling in the BigDecimal codecs, in line with the changes in avro4s.

Removed a couple of codecs that are now provided out-of-the-box by avro4s.

Changed the `avroWithSchemaMarshallers` `parse` method to use an `AvroInputStream`. I'm not entirely sure about this change, as I don't know why it was written the way it was before.

## What this does?
_Changes, features, fixes ..._

## Checklist

- [ ] Reviewed the diff to look for typos, println and format errors.
- [ ] Updated the docs accordingly.