### PR TITLE
Remove genOptions in sbt-mu-srcgen plugin

### DIFF
--- a/modules/srcgen/core/src/main/scala/higherkindness/mu/rpc/srcgen/Generator.scala
+++ b/modules/srcgen/core/src/main/scala/higherkindness/mu/rpc/srcgen/Generator.scala
@@ -37,6 +37,6 @@ trait Generator {
 
   protected def generateFrom(
       inputFile: File,
-      serializationType: String,
+      serializationType: String
   ): Option[(String, Seq[String])]
 }

--- a/modules/srcgen/core/src/main/scala/higherkindness/mu/rpc/srcgen/Generator.scala
+++ b/modules/srcgen/core/src/main/scala/higherkindness/mu/rpc/srcgen/Generator.scala
@@ -24,11 +24,10 @@ trait Generator {
 
   def generateFrom(
       files: Set[File],
-      serializationType: String,
-      options: String*
+      serializationType: String
   ): Seq[(File, String, Seq[String])] =
     inputFiles(files).flatMap(inputFile =>
-      generateFrom(inputFile, serializationType, options: _*).map {
+      generateFrom(inputFile, serializationType).map {
         case (outputPath, output) =>
           (inputFile, outputPath, output)
       }
@@ -39,6 +38,5 @@ trait Generator {
   protected def generateFrom(
       inputFile: File,
       serializationType: String,
-      options: String*
   ): Option[(String, Seq[String])]
 }

--- a/modules/srcgen/core/src/main/scala/higherkindness/mu/rpc/srcgen/GeneratorApplication.scala
+++ b/modules/srcgen/core/src/main/scala/higherkindness/mu/rpc/srcgen/GeneratorApplication.scala
@@ -50,21 +50,20 @@ abstract class GeneratorApplication[T <: Generator](generators: T*) {
     )
     val outputDir = new File(args(3))
     val options   = args.drop(4)
-    generateFrom(idlType, serializationType, inputPath.allFiles.toSet, outputDir, options: _*)
+    generateFrom(idlType, serializationType, inputPath.allFiles.toSet, outputDir)
   }
 
   def generateFrom(
       idlType: String,
       serializationType: String,
       inputFiles: Set[File],
-      outputDir: File,
-      options: String*
+      outputDir: File
   ): Seq[File] = {
     validate(
       idlTypes.contains(idlType),
       s"Unknown IDL type '$idlType'. Valid values: ${idlTypes.mkString(", ")}"
     )
-    generatorsByType(idlType).generateFrom(inputFiles, serializationType, options: _*).map {
+    generatorsByType(idlType).generateFrom(inputFiles, serializationType).map {
       case (inputFile, outputFilePath, output) =>
         val outputFile = new File(outputDir, outputFilePath)
         logger.info(s"$inputFile -> $outputFile")

--- a/modules/srcgen/core/src/main/scala/higherkindness/mu/rpc/srcgen/avro/AvroSrcGenerator.scala
+++ b/modules/srcgen/core/src/main/scala/higherkindness/mu/rpc/srcgen/avro/AvroSrcGenerator.scala
@@ -63,16 +63,14 @@ case class AvroSrcGenerator(
   override def generateFrom(
       files: Set[File],
       serializationType: String,
-      options: String*
   ): Seq[(File, String, Seq[String])] =
     super
-      .generateFrom(files, serializationType: String, options: _*)
+      .generateFrom(files, serializationType: String)
       .filter(output => files.contains(output._1))
 
   def generateFrom(
       inputFile: File,
-      serializationType: String,
-      options: String*
+      serializationType: String
   ): Option[(String, Seq[String])] =
     generateFromSchemaProtocols(
       mainGenerator.fileParser
@@ -82,26 +80,22 @@ case class AvroSrcGenerator(
           mainGenerator.classStore,
           mainGenerator.classLoader
         ),
-      serializationType,
-      options
+      serializationType
     )
 
   def generateFrom(
       input: String,
-      serializationType: String,
-      options: String*
+      serializationType: String
   ): Option[(String, Seq[String])] =
     generateFromSchemaProtocols(
       mainGenerator.stringParser
         .getSchemaOrProtocols(input, mainGenerator.schemaStore),
-      serializationType,
-      options
+      serializationType
     )
 
   private def generateFromSchemaProtocols(
       schemasOrProtocols: List[Either[Schema, Protocol]],
-      serializationType: String,
-      options: Seq[String]
+      serializationType: String
   ): Option[(String, Seq[String])] =
     Some(schemasOrProtocols)
       .filter(_.nonEmpty)
@@ -109,12 +103,11 @@ case class AvroSrcGenerator(
         case Right(p) => Some(p)
         case _        => None
       })
-      .map(generateFrom(_, serializationType, options))
+      .map(generateFrom(_, serializationType))
 
   def generateFrom(
       protocol: Protocol,
-      serializationType: String,
-      options: Seq[String]
+      serializationType: String
   ): (String, Seq[String]) = {
 
     val outputPath =
@@ -152,7 +145,6 @@ case class AvroSrcGenerator(
     }
 
     val extraParams: List[String] =
-      if (options.isEmpty) {
         s"compressionType = ${compressionTypeGen.value}" +:
           (if (useIdiomaticEndpoints) {
              List(
@@ -160,7 +152,6 @@ case class AvroSrcGenerator(
                "methodNameStyle = Capitalize"
              )
            } else Nil)
-      } else options.toList
 
     val serviceParams: String = (serializationType +: extraParams).mkString(",")
 

--- a/modules/srcgen/core/src/main/scala/higherkindness/mu/rpc/srcgen/avro/AvroSrcGenerator.scala
+++ b/modules/srcgen/core/src/main/scala/higherkindness/mu/rpc/srcgen/avro/AvroSrcGenerator.scala
@@ -62,7 +62,7 @@ case class AvroSrcGenerator(
   // so we then reduce our output to that based on this fileset
   override def generateFrom(
       files: Set[File],
-      serializationType: String,
+      serializationType: String
   ): Seq[(File, String, Seq[String])] =
     super
       .generateFrom(files, serializationType: String)
@@ -145,13 +145,13 @@ case class AvroSrcGenerator(
     }
 
     val extraParams: List[String] =
-        s"compressionType = ${compressionTypeGen.value}" +:
-          (if (useIdiomaticEndpoints) {
-             List(
-               s"""namespace = Some("${protocol.getNamespace}")""",
-               "methodNameStyle = Capitalize"
-             )
-           } else Nil)
+      s"compressionType = ${compressionTypeGen.value}" +:
+        (if (useIdiomaticEndpoints) {
+           List(
+             s"""namespace = Some("${protocol.getNamespace}")""",
+             "methodNameStyle = Capitalize"
+           )
+         } else Nil)
 
     val serviceParams: String = (serializationType +: extraParams).mkString(",")
 

--- a/modules/srcgen/core/src/main/scala/higherkindness/mu/rpc/srcgen/openapi/OpenApiSrcGenerator.scala
+++ b/modules/srcgen/core/src/main/scala/higherkindness/mu/rpc/srcgen/openapi/OpenApiSrcGenerator.scala
@@ -54,8 +54,7 @@ object OpenApiSrcGenerator {
 
     protected def generateFrom(
         inputFile: File,
-        serializationType: String,
-        options: String*
+        serializationType: String
     ): Option[(String, Seq[String])] =
       getCode[IO](inputFile).value.unsafeRunSync()
 

--- a/modules/srcgen/core/src/main/scala/higherkindness/mu/rpc/srcgen/proto/ProtoSrcGenerator.scala
+++ b/modules/srcgen/core/src/main/scala/higherkindness/mu/rpc/srcgen/proto/ProtoSrcGenerator.scala
@@ -58,8 +58,7 @@ object ProtoSrcGenerator {
 
     def generateFrom(
         inputFile: File,
-        serializationType: String,
-        options: String*
+        serializationType: String
     ): Option[(String, Seq[String])] =
       getCode[IO](inputFile).map(Some(_)).unsafeRunSync
 

--- a/modules/srcgen/core/src/test/scala/higherkindness/mu/rpc/srcgen/AvroScalaGeneratorArbitrary.scala
+++ b/modules/srcgen/core/src/test/scala/higherkindness/mu/rpc/srcgen/AvroScalaGeneratorArbitrary.scala
@@ -27,7 +27,6 @@ trait AvroScalaGeneratorArbitrary {
       expectedOutputFilePath: String,
       serializationType: String,
       marshallersImports: List[MarshallersImport],
-      options: Seq[String],
       compressionTypeGen: CompressionTypeGen,
       useIdiomaticEndpoints: UseIdiomaticEndpoints
   )
@@ -35,7 +34,6 @@ trait AvroScalaGeneratorArbitrary {
   def generateOutput(
       serializationType: String,
       marshallersImports: List[MarshallersImport],
-      options: Option[String],
       compressionTypeGen: CompressionTypeGen,
       useIdiomaticEndpoints: UseIdiomaticEndpoints
   ): List[String] = {
@@ -46,13 +44,11 @@ trait AvroScalaGeneratorArbitrary {
       .mkString("\n")
 
     val serviceParams: Seq[String] =
-      if (options.isEmpty) {
-        serializationType ::
-          s"compressionType = ${compressionTypeGen.value}" ::
-          List(s"""namespace = Some("foo.bar")""", "methodNameStyle = Capitalize").filter(_ =>
-            useIdiomaticEndpoints
-          )
-      } else serializationType +: options.toSeq
+      serializationType ::
+        s"compressionType = ${compressionTypeGen.value}" ::
+        List(s"""namespace = Some("foo.bar")""", "methodNameStyle = Capitalize").filter(_ =>
+          useIdiomaticEndpoints
+        )
 
     s"""
          |package foo.bar
@@ -106,7 +102,6 @@ trait AvroScalaGeneratorArbitrary {
       inputResourcePath     <- Gen.oneOf("/avro/GreeterService.avpr", "/avro/GreeterService.avdl")
       serializationType     <- Gen.oneOf("Avro", "AvroWithSchema", "Protobuf")
       marshallersImports    <- Gen.listOf(marshallersImportGen(serializationType))
-      options               <- Gen.option("Gzip")
       compressionTypeGen    <- Gen.oneOf(GzipGen, NoCompressionGen)
       useIdiomaticEndpoints <- Arbitrary.arbBool.arbitrary.map(UseIdiomaticEndpoints(_))
     } yield Scenario(
@@ -114,14 +109,12 @@ trait AvroScalaGeneratorArbitrary {
       generateOutput(
         serializationType,
         marshallersImports,
-        options,
         compressionTypeGen,
         useIdiomaticEndpoints
       ),
       "foo/bar/MyGreeterService.scala",
       serializationType,
       marshallersImports,
-      options.toSeq,
       compressionTypeGen,
       useIdiomaticEndpoints
     )

--- a/modules/srcgen/core/src/test/scala/higherkindness/mu/rpc/srcgen/AvroSrcGenTests.scala
+++ b/modules/srcgen/core/src/test/scala/higherkindness/mu/rpc/srcgen/AvroSrcGenTests.scala
@@ -45,8 +45,7 @@ class AvroSrcGenTests extends RpcBaseTestSuite with Checkers {
         scenario.useIdiomaticEndpoints
       ).generateFrom(
         resource(scenario.inputResourcePath).mkString,
-        scenario.serializationType,
-        scenario.options: _*
+        scenario.serializationType
       )
     output should not be empty
     output forall {

--- a/modules/srcgen/core/src/test/scala/higherkindness/mu/rpc/srcgen/OpenApiSrcGenTests.scala
+++ b/modules/srcgen/core/src/test/scala/higherkindness/mu/rpc/srcgen/OpenApiSrcGenTests.scala
@@ -30,7 +30,7 @@ class OpenApiSrcGenTests extends FlatSpec with OptionValues {
 
   it should "generate correct Scala" in {
     val (_, path, code) = OpenApiSrcGenerator(HttpImpl.Http4sV20, resourcesFiles.toPath())
-      .generateFrom(Set(openApiFile), "", "")
+      .generateFrom(Set(openApiFile), "")
       .headOption
       .value
     path should ===("bookstore/book.scala")

--- a/modules/srcgen/core/src/test/scala/higherkindness/mu/rpc/srcgen/ProtoSrcGenTests.scala
+++ b/modules/srcgen/core/src/test/scala/higherkindness/mu/rpc/srcgen/ProtoSrcGenTests.scala
@@ -40,7 +40,7 @@ class ProtoSrcGenTests extends RpcBaseTestSuite with OptionValues {
       val result: Option[(String, String)] =
         ProtoSrcGenerator
           .build(NoCompressionGen, UseIdiomaticEndpoints(false), Fs2Stream, new java.io.File("."))
-          .generateFrom(files = Set(protoFile("book")), serializationType = "", options = "")
+          .generateFrom(files = Set(protoFile("book")), serializationType = "")
           .map(t => (t._2, t._3.mkString("\n").clean))
           .headOption
 
@@ -57,7 +57,7 @@ class ProtoSrcGenTests extends RpcBaseTestSuite with OptionValues {
             MonixObservable,
             new java.io.File(".")
           )
-          .generateFrom(files = Set(protoFile("book")), serializationType = "", options = "")
+          .generateFrom(files = Set(protoFile("book")), serializationType = "")
           .map(t => (t._2, t._3.mkString("\n").clean))
           .headOption
 

--- a/modules/srcgen/plugin/src/main/scala/higherkindness/mu/rpc/srcgen/SrcGenPlugin.scala
+++ b/modules/srcgen/plugin/src/main/scala/higherkindness/mu/rpc/srcgen/SrcGenPlugin.scala
@@ -68,15 +68,6 @@ object SrcGenPlugin extends AutoPlugin {
           "in subpackages based on the namespaces declared in the IDL files."
       )
 
-    @deprecated(
-      "Use the specific settings like `muSrcGenCompressionType` or `muSrcGenIdiomaticEndpoints`",
-      "0.18.4"
-    )
-    lazy val genOptions: SettingKey[Seq[String]] =
-      settingKey[Seq[String]](
-        "Options for the generator, such as additional @service annotation parameters in srcGen."
-      )
-
     lazy val muSrcGenBigDecimal: SettingKey[BigDecimalTypeGen] =
       settingKey[BigDecimalTypeGen](
         "The Scala generated type for `decimals`. Possible values are `ScalaBigDecimalGen` and `ScalaBigDecimalTaggedGen`" +
@@ -127,7 +118,6 @@ object SrcGenPlugin extends AutoPlugin {
     muSrcGenSourceDirs := Seq((Compile / resourceDirectory).value),
     muSrcGenIdlTargetDir := (Compile / resourceManaged).value / muSrcGenIdlType.value,
     muSrcGenTargetDir := (Compile / sourceManaged).value,
-    genOptions := Seq.empty,
     muSrcGenBigDecimal := ScalaBigDecimalTaggedGen,
     muSrcGenMarshallerImports := {
       if (muSrcGenSerializationType.value == "Avro" || muSrcGenSerializationType.value == "AvroWithSchema")
@@ -187,7 +177,6 @@ object SrcGenPlugin extends AutoPlugin {
               ),
               muSrcGenIdlType.value,
               muSrcGenSerializationType.value,
-              genOptions.value,
               muSrcGenTargetDir.value,
               target.value / "srcGen"
             )(muSrcGenIdlTargetDir.value.allPaths.get.toSet).toSeq
@@ -212,13 +201,12 @@ object SrcGenPlugin extends AutoPlugin {
       generator: GeneratorApplication[_],
       idlType: String,
       serializationType: String,
-      options: Seq[String],
       targetDir: File,
       cacheDir: File
   ): Set[File] => Set[File] =
     FileFunction.cached(cacheDir, FilesInfo.lastModified, FilesInfo.exists) {
       inputFiles: Set[File] =>
-        generator.generateFrom(idlType, serializationType, inputFiles, targetDir, options: _*).toSet
+        generator.generateFrom(idlType, serializationType, inputFiles, targetDir).toSet
     }
 
   private def extractIDLDefinitionsFromJar(

--- a/modules/srcgen/plugin/src/sbt-test/sbt-mu-srcgen/gzipCompression/test
+++ b/modules/srcgen/plugin/src/sbt-test/sbt-mu-srcgen/gzipCompression/test
@@ -9,15 +9,6 @@ $ delete target/scala-2.12/src_managed/main/io/higherkindness/service.scala
 $ exists src/main/resources/service.avdl
 > 'set muSrcGenIdlType := "avro"'
 > 'set muSrcGenSerializationType := "AvroWithSchema"'
-> 'set genOptions := Seq("Gzip")'
-> muSrcGen
-> compile
-$ exists target/scala-2.12/src_managed/main/io/higherkindness/service.scala
-$ delete target/scala-2.12/src_managed/main/io/higherkindness/service.scala
-
-$ exists src/main/resources/service.avdl
-> 'set muSrcGenIdlType := "avro"'
-> 'set muSrcGenSerializationType := "AvroWithSchema"'
 > 'set muSrcGenCompressionType := higherkindness.mu.rpc.srcgen.Model.GzipGen'
 > muSrcGen
 > compile


### PR DESCRIPTION
## What this does?
Remove genOptions in sbt-mu-srcgen plugin
## Checklist

- [x] Reviewed the diff to look for typos, println and format errors.
- [x] Updated the docs accordingly.

