### PR TITLE
Adds a prometheus builder for full metrics

### DIFF
--- a/modules/config/src/main/scala/higherkindness/mu/rpc/config.scala
+++ b/modules/config/src/main/scala/higherkindness/mu/rpc/config.scala
@@ -27,7 +27,7 @@ package object config {
   }
 
   implicit def syncConfigM[F[_]](implicit F: Sync[F]): ConfigM[F] = new ConfigM[F] {
-    def load: F[Config] = F.delay(loadConfigOrThrow[Config](ConfigFactory.load()))
+    def load: F[Config] = F.delay(ConfigSource.fromConfig(ConfigFactory.load()).loadOrThrow[Config])
   }
 
 }

--- a/modules/metrics/prometheus/src/test/scala/higherkindness/mu/rpc/prometheus/PrometheusMetricsTests.scala
+++ b/modules/metrics/prometheus/src/test/scala/higherkindness/mu/rpc/prometheus/PrometheusMetricsTests.scala
@@ -169,8 +169,9 @@ class PrometheusMetricsTests extends Properties("PrometheusMetrics") {
         (for {
           metrics <- PrometheusMetrics.build[IO](registry, prefix)
           op1 <- (1 to numberOfCalls).toList
-            .map(_ => metrics.recordTotalTime(methodInfo, status, elapsed.toLong, Some(classifier)))
-            .sequence_
+            .traverse_(_ =>
+              metrics.recordTotalTime(methodInfo, status, elapsed.toLong, Some(classifier))
+            )
             .map { _ =>
               checkMetrics(
                 registry,
@@ -195,8 +196,9 @@ class PrometheusMetricsTests extends Properties("PrometheusMetrics") {
         (for {
           metrics <- PrometheusMetrics.buildFullTotal[IO](registry, prefix)
           op1 <- (1 to numberOfCalls).toList
-            .map(_ => metrics.recordTotalTime(methodInfo, status, elapsed.toLong, Some(classifier)))
-            .sequence_
+            .traverse_(_ =>
+              metrics.recordTotalTime(methodInfo, status, elapsed.toLong, Some(classifier))
+            )
             .map { _ =>
               checkMetrics(
                 registry,

--- a/modules/metrics/prometheus/src/test/scala/higherkindness/mu/rpc/prometheus/PrometheusMetricsTests.scala
+++ b/modules/metrics/prometheus/src/test/scala/higherkindness/mu/rpc/prometheus/PrometheusMetricsTests.scala
@@ -160,7 +160,7 @@ class PrometheusMetricsTests extends Properties("PrometheusMetrics") {
         } yield op1).unsafeRunSync()
     }
 
-  property("creates and updates timer for total time") =
+  property("creates and updates timer for total time metrics") =
     forAllNoShrink(methodInfoGen, Gen.chooseNum[Int](1, 10), statusGen, Gen.chooseNum(100, 1000)) {
       (methodInfo: GrpcMethodInfo, numberOfCalls: Int, status: Status, elapsed: Int) =>
         val registry   = new CollectorRegistry()
@@ -179,6 +179,33 @@ class PrometheusMetricsTests extends Properties("PrometheusMetrics") {
                 List(
                   classifier,
                   methodTypeDescription(methodInfo),
+                  statusDescription(MetricsOps.grpcStatusFromRawStatus(status))
+                )
+              )(checkSeriesSamples(metricName, numberOfCalls, elapsed))
+            }
+        } yield op1).unsafeRunSync()
+    }
+
+  property("creates and updates timer for full total time metrics") =
+    forAllNoShrink(methodInfoGen, Gen.chooseNum[Int](1, 10), statusGen, Gen.chooseNum(100, 1000)) {
+      (methodInfo: GrpcMethodInfo, numberOfCalls: Int, status: Status, elapsed: Int) =>
+        val registry   = new CollectorRegistry()
+        val metricName = s"${prefix}_calls_total"
+
+        (for {
+          metrics <- PrometheusMetrics.buildFullTotal[IO](registry, prefix)
+          op1 <- (1 to numberOfCalls).toList
+            .map(_ => metrics.recordTotalTime(methodInfo, status, elapsed.toLong, Some(classifier)))
+            .sequence_
+            .map { _ =>
+              checkMetrics(
+                registry,
+                metricName,
+                List("classifier", "service", "method", "status"),
+                List(
+                  classifier,
+                  methodInfo.serviceName,
+                  methodInfo.methodName,
                   statusDescription(MetricsOps.grpcStatusFromRawStatus(status))
                 )
               )(checkSeriesSamples(metricName, numberOfCalls, elapsed))


### PR DESCRIPTION
## What this does?

Fixes #635

This adds a new builder for construct a prometheus metrics with the service and method names included in the total time histogram.

Since histograms could have some performance problems when the granularity of the labels increase, we can remove the headers histogram from the new builder (which is not providing too much value due to the number of labels). The user could always add their own metrics.

This also provides a sample about how to tune the metric builder.

## Checklist

- [x] Reviewed the diff to look for typos, println and format errors.
- [ ] Updated the docs accordingly.

