### PR TITLE
Automatically register muSrcGen as a sourceGenerator

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -206,7 +206,7 @@ lazy val kafka = project
   .settings(kafkaSettings)
 
 ////////////////
-//// IDLGEN ////
+//// SRCGEN ////
 ////////////////
 
 lazy val `srcgen-core` = project

--- a/docs/src/main/docs/generate-sources-from-idl/avro.md
+++ b/docs/src/main/docs/generate-sources-from-idl/avro.md
@@ -28,9 +28,6 @@ muSrcGenIdlType := IdlType.Avro
 
 // Make it easy for 3rd-party clients to communicate with our gRPC server
 muSrcGenIdiomaticEndpoints := true
-
-// Run the source generation automatically before compilation
-sourceGenerators in Compile += (muSrcGen in Compile).taskValue
 ```
 
 Finally, make sure you have enabled the scalamacros compiler plugin so that

--- a/docs/src/main/docs/generate-sources-from-idl/index.md
+++ b/docs/src/main/docs/generate-sources-from-idl/index.md
@@ -38,14 +38,11 @@ addSbtPlugin("io.higherkindness" % "sbt-mu-srcgen" % "0.20.1")
 
 The `muSrcGen` sbt task generates Scala source code from IDL files.
 
-The easiest way to use the plugin is by integrating the source generation in
-your compile process by adding this line to your `build.sbt` file:
+The plugin will automatically integrate the source generation into your compile
+process, so the sources are generated before compilation when you run the
+`compile` task.
 
-```scala
-sourceGenerators in Compile += (muSrcGen in Compile).taskValue
-```
-
-Otherwise, you can run the sbt task manually:
+You can also run the sbt task manually:
 
 ```sh
 $ sbt muSrcGen
@@ -152,7 +149,6 @@ sbt module containing the IDL definitions (`foo-domain`):
       muSrcGenSerializationType := SerializationType.AvroWithSchema,
       muSrcGenJarNames := Seq("foo-domain"),
       muSrcGenTargetDir := (Compile / sourceManaged).value / "compiled_avro",
-      sourceGenerators in Compile += (Compile / muSrcGen).taskValue,
       libraryDependencies ++= Seq(
         "io.higherkindness" %% "mu-rpc-channel" % V.muRPC
       )

--- a/docs/src/main/docs/generate-sources-from-idl/openapi.md
+++ b/docs/src/main/docs/generate-sources-from-idl/openapi.md
@@ -28,9 +28,6 @@ muSrcGenIdlType := IdlType.OpenAPI
 
 // Generate code that is compatible with http4s v0.20.x
 muSrcGenOpenApiHttpImpl := higherkindness.mu.rpc.idlgen.openapi.OpenApiSrcGenerator.HttpImpl.Http4sV20
-
-// Run the source generation automatically before compilation
-sourceGenerators in Compile += (muSrcGen in Compile).taskValue
 ```
 
 Finally add the appropriate Circe and http4s dependencies so the generated code

--- a/docs/src/main/docs/generate-sources-from-idl/proto.md
+++ b/docs/src/main/docs/generate-sources-from-idl/proto.md
@@ -28,9 +28,6 @@ muSrcGenIdlType := IdlType.Proto
 
 // Make it easy for 3rd-party clients to communicate with our gRPC server
 muSrcGenIdlGenIdiomaticEndpoints := true
-
-// Run the source generation automatically before compilation
-sourceGenerators in Compile += (muSrcGen in Compile).taskValue
 ```
 
 Finally, make sure you have enabled the scalamacros compiler plugin so that

--- a/modules/srcgen/plugin/src/main/scala/higherkindness/mu/rpc/srcgen/SrcGenPlugin.scala
+++ b/modules/srcgen/plugin/src/main/scala/higherkindness/mu/rpc/srcgen/SrcGenPlugin.scala
@@ -205,6 +205,13 @@ object SrcGenPlugin extends AutoPlugin {
     }
   )
 
+  lazy val sourceGeneratorSettings: Seq[Def.Setting[_]] = Seq(
+    // Register the muSrcGen task as a source generator.
+    // If we don't do this, the compile task will not see the
+    // generated files even if the user manually runs the muSrcGen task.
+    sourceGenerators in Compile += (muSrcGen in Compile).taskValue
+  )
+
   private def srcGenTask(
       generator: GeneratorApplication[_],
       idlType: IdlType,
@@ -253,5 +260,5 @@ object SrcGenPlugin extends AutoPlugin {
   }
 
   override def projectSettings: Seq[Def.Setting[_]] =
-    defaultSettings ++ taskSettings ++ packagingSettings
+    defaultSettings ++ taskSettings ++ packagingSettings ++ sourceGeneratorSettings
 }

--- a/modules/srcgen/plugin/src/sbt-test/sbt-mu-srcgen/avroWithSchema/build.sbt
+++ b/modules/srcgen/plugin/src/sbt-test/sbt-mu-srcgen/avroWithSchema/build.sbt
@@ -1,5 +1,7 @@
 version := sys.props("version")
 
 libraryDependencies ++= Seq(
-  "io.higherkindness" %% "mu-rpc-server" % sys.props("version")
+  "io.higherkindness" %% "mu-rpc-channel" % sys.props("version")
 )
+
+addCompilerPlugin("org.scalamacros" % "paradise" % "2.1.1" cross CrossVersion.patch)

--- a/modules/srcgen/plugin/src/sbt-test/sbt-mu-srcgen/avroWithSchema/src/main/resources/service.avdl
+++ b/modules/srcgen/plugin/src/sbt-test/sbt-mu-srcgen/avroWithSchema/src/main/resources/service.avdl
@@ -1,5 +1,5 @@
 @namespace("io.higherkindness")
-protocol service {
+protocol MyService {
 
   record Foo {
     string bar;

--- a/modules/srcgen/plugin/src/sbt-test/sbt-mu-srcgen/avroWithSchema/test
+++ b/modules/srcgen/plugin/src/sbt-test/sbt-mu-srcgen/avroWithSchema/test
@@ -2,13 +2,13 @@ $ exists src/main/resources/service.avdl
 > 'set muSrcGenIdlType := higherkindness.mu.rpc.srcgen.Model.IdlType.Avro'
 > 'set muSrcGenSerializationType := higherkindness.mu.rpc.srcgen.Model.SerializationType.Avro'
 > muSrcGen
+$ exists target/scala-2.12/src_managed/main/io/higherkindness/MyService.scala
 > compile
-$ exists target/scala-2.12/src_managed/main/io/higherkindness/service.scala
-$ delete target/scala-2.12/src_managed/main/io/higherkindness/service.scala
+$ delete target/scala-2.12/src_managed/main/io/higherkindness/MyService.scala
 
 $ exists src/main/resources/service.avdl
 > 'set muSrcGenIdlType := higherkindness.mu.rpc.srcgen.Model.IdlType.Avro'
 > 'set muSrcGenSerializationType := higherkindness.mu.rpc.srcgen.Model.SerializationType.AvroWithSchema'
 > muSrcGen
+$ exists target/scala-2.12/src_managed/main/io/higherkindness/MyService.scala
 > compile
-$ exists target/scala-2.12/src_managed/main/io/higherkindness/service.scala

--- a/modules/srcgen/plugin/src/sbt-test/sbt-mu-srcgen/basic/src/main/resources/model.avdl
+++ b/modules/srcgen/plugin/src/sbt-test/sbt-mu-srcgen/basic/src/main/resources/model.avdl
@@ -1,4 +1,4 @@
-@namespace("")
+@namespace("foo")
 protocol model {
 
   record Person {

--- a/modules/srcgen/plugin/src/sbt-test/sbt-mu-srcgen/basic/src/main/scala/model.scala
+++ b/modules/srcgen/plugin/src/sbt-test/sbt-mu-srcgen/basic/src/main/scala/model.scala
@@ -1,3 +1,0 @@
-import higherkindness.mu.rpc.protocol._
-
-case class Person(id: Long, name: String, email: Option[String])

--- a/modules/srcgen/plugin/src/sbt-test/sbt-mu-srcgen/basic/test
+++ b/modules/srcgen/plugin/src/sbt-test/sbt-mu-srcgen/basic/test
@@ -1,6 +1,5 @@
 $ exists src/main/resources/model.avdl
 > 'set muSrcGenIdlType := higherkindness.mu.rpc.srcgen.Model.IdlType.Avro'
 > muSrcGen
+$ exists target/scala-2.12/src_managed/main/foo/model.scala
 > compile
-$ exists target/scala-2.12/src_managed/main/model.scala
-$ delete target/scala-2.12/src_managed/main/model.scala

--- a/modules/srcgen/plugin/src/sbt-test/sbt-mu-srcgen/gzipCompression/build.sbt
+++ b/modules/srcgen/plugin/src/sbt-test/sbt-mu-srcgen/gzipCompression/build.sbt
@@ -1,5 +1,7 @@
 version := sys.props("version")
 
 libraryDependencies ++= Seq(
-  "io.higherkindness" %% "mu-rpc-server" % sys.props("version")
+  "io.higherkindness" %% "mu-rpc-channel" % sys.props("version")
 )
+
+addCompilerPlugin("org.scalamacros" % "paradise" % "2.1.1" cross CrossVersion.patch)

--- a/modules/srcgen/plugin/src/sbt-test/sbt-mu-srcgen/gzipCompression/src/main/resources/service.avdl
+++ b/modules/srcgen/plugin/src/sbt-test/sbt-mu-srcgen/gzipCompression/src/main/resources/service.avdl
@@ -1,5 +1,5 @@
 @namespace("io.higherkindness")
-protocol service {
+protocol MyService {
 
   record Foo {
     string bar;

--- a/modules/srcgen/plugin/src/sbt-test/sbt-mu-srcgen/gzipCompression/test
+++ b/modules/srcgen/plugin/src/sbt-test/sbt-mu-srcgen/gzipCompression/test
@@ -2,23 +2,23 @@ $ exists src/main/resources/service.avdl
 > 'set muSrcGenIdlType := higherkindness.mu.rpc.srcgen.Model.IdlType.Avro'
 > 'set muSrcGenSerializationType := higherkindness.mu.rpc.srcgen.Model.SerializationType.Avro'
 > muSrcGen
+$ exists target/scala-2.12/src_managed/main/io/higherkindness/MyService.scala
 > compile
-$ exists target/scala-2.12/src_managed/main/io/higherkindness/service.scala
-$ delete target/scala-2.12/src_managed/main/io/higherkindness/service.scala
+$ delete target/scala-2.12/src_managed/main/io/higherkindness/MyService.scala
 
 $ exists src/main/resources/service.avdl
 > 'set muSrcGenIdlType := higherkindness.mu.rpc.srcgen.Model.IdlType.Avro'
 > 'set muSrcGenSerializationType := higherkindness.mu.rpc.srcgen.Model.SerializationType.AvroWithSchema'
 > 'set muSrcGenCompressionType := higherkindness.mu.rpc.srcgen.Model.GzipGen'
 > muSrcGen
+$ exists target/scala-2.12/src_managed/main/io/higherkindness/MyService.scala
 > compile
-$ exists target/scala-2.12/src_managed/main/io/higherkindness/service.scala
-$ delete target/scala-2.12/src_managed/main/io/higherkindness/service.scala
+$ delete target/scala-2.12/src_managed/main/io/higherkindness/MyService.scala
 
 $ exists src/main/resources/service.avdl
 > 'set muSrcGenIdlType := higherkindness.mu.rpc.srcgen.Model.IdlType.Avro'
 > 'set muSrcGenSerializationType := higherkindness.mu.rpc.srcgen.Model.SerializationType.AvroWithSchema'
 > 'set muSrcGenCompressionType := higherkindness.mu.rpc.srcgen.Model.NoCompressionGen'
 > muSrcGen
+$ exists target/scala-2.12/src_managed/main/io/higherkindness/MyService.scala
 > compile
-$ exists target/scala-2.12/src_managed/main/io/higherkindness/service.scala

--- a/modules/srcgen/plugin/src/sbt-test/sbt-mu-srcgen/idiomaticEndpoints/build.sbt
+++ b/modules/srcgen/plugin/src/sbt-test/sbt-mu-srcgen/idiomaticEndpoints/build.sbt
@@ -1,5 +1,7 @@
 version := sys.props("version")
 
 libraryDependencies ++= Seq(
-  "io.higherkindness" %% "mu-rpc-server" % sys.props("version")
+  "io.higherkindness" %% "mu-rpc-channel" % sys.props("version")
 )
+
+addCompilerPlugin("org.scalamacros" % "paradise" % "2.1.1" cross CrossVersion.patch)

--- a/modules/srcgen/plugin/src/sbt-test/sbt-mu-srcgen/idiomaticEndpoints/src/main/resources/service.avdl
+++ b/modules/srcgen/plugin/src/sbt-test/sbt-mu-srcgen/idiomaticEndpoints/src/main/resources/service.avdl
@@ -1,5 +1,5 @@
 @namespace("io.higherkindness")
-protocol service {
+protocol MyService {
 
   record Foo {
     string bar;

--- a/modules/srcgen/plugin/src/sbt-test/sbt-mu-srcgen/idiomaticEndpoints/test
+++ b/modules/srcgen/plugin/src/sbt-test/sbt-mu-srcgen/idiomaticEndpoints/test
@@ -2,14 +2,14 @@ $ exists src/main/resources/service.avdl
 > 'set muSrcGenIdlType := higherkindness.mu.rpc.srcgen.Model.IdlType.Avro'
 > 'set muSrcGenSerializationType := higherkindness.mu.rpc.srcgen.Model.SerializationType.Avro'
 > muSrcGen
+$ exists target/scala-2.12/src_managed/main/io/higherkindness/MyService.scala
 > compile
-$ exists target/scala-2.12/src_managed/main/io/higherkindness/service.scala
-$ delete target/scala-2.12/src_managed/main/io/higherkindness/service.scala
+$ delete target/scala-2.12/src_managed/main/io/higherkindness/MyService.scala
 
 $ exists src/main/resources/service.avdl
 > 'set muSrcGenIdlType := higherkindness.mu.rpc.srcgen.Model.IdlType.Avro'
 > 'set muSrcGenSerializationType := higherkindness.mu.rpc.srcgen.Model.SerializationType.AvroWithSchema'
 > 'set muSrcGenIdiomaticEndpoints := true'
 > muSrcGen
+$ exists target/scala-2.12/src_managed/main/io/higherkindness/MyService.scala
 > compile
-$ exists target/scala-2.12/src_managed/main/io/higherkindness/service.scala

--- a/modules/srcgen/plugin/src/sbt-test/sbt-mu-srcgen/importMarshallers/build.sbt
+++ b/modules/srcgen/plugin/src/sbt-test/sbt-mu-srcgen/importMarshallers/build.sbt
@@ -1,6 +1,15 @@
-version := "1-SNAPSHOT"
+version := sys.props("version")
 
 libraryDependencies ++= Seq(
-  "io.higherkindness" %% "mu-rpc-server" % sys.props("version"),
+  "io.higherkindness" %% "mu-rpc-channel" % sys.props("version"),
   "io.higherkindness" %% "mu-rpc-marshallers-jodatime" % sys.props("version")
 )
+
+addCompilerPlugin("org.scalamacros" % "paradise" % "2.1.1" cross CrossVersion.patch)
+
+val checkCustomImport = taskKey[Unit]("Check the custom import is added to the generated file")
+checkCustomImport := {
+  val generatedFile = file("target/scala-2.12/src_managed/main/io/higherkindness/MyService.scala")
+  val lines = sbt.io.IO.readLines(generatedFile)
+  assert(lines.contains("import com.sample.marshallers._"))
+}

--- a/modules/srcgen/plugin/src/sbt-test/sbt-mu-srcgen/importMarshallers/src/main/resources/service.avdl
+++ b/modules/srcgen/plugin/src/sbt-test/sbt-mu-srcgen/importMarshallers/src/main/resources/service.avdl
@@ -1,5 +1,5 @@
 @namespace("io.higherkindness")
-protocol service {
+protocol MyService {
 
   record Foo {
     string bar;

--- a/modules/srcgen/plugin/src/sbt-test/sbt-mu-srcgen/importMarshallers/test
+++ b/modules/srcgen/plugin/src/sbt-test/sbt-mu-srcgen/importMarshallers/test
@@ -2,30 +2,29 @@ $ exists src/main/resources/service.avdl
 > 'set muSrcGenIdlType := higherkindness.mu.rpc.srcgen.Model.IdlType.Avro'
 > 'set muSrcGenSerializationType := higherkindness.mu.rpc.srcgen.Model.SerializationType.Avro'
 > muSrcGen
+$ exists target/scala-2.12/src_managed/main/io/higherkindness/MyService.scala
 > compile
-$ exists target/scala-2.12/src_managed/main/io/higherkindness/service.scala
-$ delete target/scala-2.12/src_managed/main/io/higherkindness/service.scala
+$ delete target/scala-2.12/src_managed/main/io/higherkindness/MyService.scala
 
 $ exists src/main/resources/service.avdl
 > 'set muSrcGenIdlType := higherkindness.mu.rpc.srcgen.Model.IdlType.Avro'
 > 'set muSrcGenMarshallerImports := List()'
 > muSrcGen
+$ exists target/scala-2.12/src_managed/main/io/higherkindness/MyService.scala
 > compile
-$ exists target/scala-2.12/src_managed/main/io/higherkindness/service.scala
-$ delete target/scala-2.12/src_managed/main/io/higherkindness/service.scala
+$ delete target/scala-2.12/src_managed/main/io/higherkindness/MyService.scala
 
 $ exists src/main/resources/service.avdl
 > 'set muSrcGenIdlType := higherkindness.mu.rpc.srcgen.Model.IdlType.Avro'
 > 'set muSrcGenMarshallerImports := List(higherkindness.mu.rpc.srcgen.Model.CustomMarshallersImport("com.sample.marshallers._"))'
 > muSrcGen
-> compile
-$ exists target/scala-2.12/src_managed/main/io/higherkindness/service.scala
-$ delete target/scala-2.12/src_managed/main/io/higherkindness/service.scala
+$ exists target/scala-2.12/src_managed/main/io/higherkindness/MyService.scala
+> checkCustomImport
+$ delete target/scala-2.12/src_managed/main/io/higherkindness/MyService.scala
 
 $ exists src/main/resources/service.avdl
 > 'set muSrcGenIdlType := higherkindness.mu.rpc.srcgen.Model.IdlType.Avro'
 > 'set muSrcGenMarshallerImports := List(higherkindness.mu.rpc.srcgen.Model.BigDecimalAvroMarshallers, higherkindness.mu.rpc.srcgen.Model.JavaTimeDateAvroMarshallers, higherkindness.mu.rpc.srcgen.Model.JodaDateTimeAvroMarshallers, higherkindness.mu.rpc.srcgen.Model.CustomMarshallersImport("com.sample.marshallers._"))'
 > muSrcGen
-> compile
-$ exists target/scala-2.12/src_managed/main/io/higherkindness/service.scala
-$ delete target/scala-2.12/src_managed/main/io/higherkindness/service.scala
+$ exists target/scala-2.12/src_managed/main/io/higherkindness/MyService.scala
+> checkCustomImport

--- a/modules/srcgen/plugin/src/sbt-test/sbt-mu-srcgen/srcGenFromDirs/build.sbt
+++ b/modules/srcgen/plugin/src/sbt-test/sbt-mu-srcgen/srcGenFromDirs/build.sbt
@@ -5,16 +5,13 @@ lazy val root = project
   .settings(name := "root")
   .settings(version := "1.0.0")
   .settings(Seq(
-    publishMavenStyle := true,
-    mappings in (Compile, packageBin) ~= { _.filter(!_._1.getName.endsWith(".class")) },
     muSrcGenIdlType := IdlType.Avro,
     muSrcGenSourceDirs := Seq(
       (Compile / resourceDirectory).value / "domain",
-      (Compile / resourceDirectory).value / "protocol"),
-    muSrcGenTargetDir := (Compile / sourceManaged).value / "compiled_avro",
-    sourceGenerators in Compile += (Compile / muSrcGen).taskValue,
+      (Compile / resourceDirectory).value / "protocol"
+    ),
+    muSrcGenTargetDir := (Compile / sourceManaged).value / "generated_from_avro",
     libraryDependencies ++= Seq(
-      "io.higherkindness"    %% "mu-rpc-channel" % sys.props("version"),
-      "com.chuusai" %% "shapeless"        % "2.3.2"
+      "io.higherkindness" %% "mu-rpc-channel" % sys.props("version")
     )
   ))

--- a/modules/srcgen/plugin/src/sbt-test/sbt-mu-srcgen/srcGenFromDirs/test
+++ b/modules/srcgen/plugin/src/sbt-test/sbt-mu-srcgen/srcGenFromDirs/test
@@ -1,9 +1,9 @@
 > publishLocal
+$ exists target/scala-2.12/src_managed/main/generated_from_avro/foo/bar/Domain.scala
+$ exists target/scala-2.12/src_managed/main/generated_from_avro/foo/bar/Protocol.scala
+$ exists target/scala-2.12/classes/foo/bar/DomainRequest.class
+$ exists target/scala-2.12/classes/foo/bar/DomainResponse.class
+$ exists target/scala-2.12/classes/foo/bar/ProtocolRequest.class
+$ exists target/scala-2.12/classes/foo/bar/ProtocolResponse.class
 $ exists target/scala-2.12/classes/domain/Domain.avdl
 $ exists target/scala-2.12/classes/protocol/Protocol.avdl
-$ exists target/scala-2.12/src_managed/main/compiled_avro/foo/bar/Domain.scala
-$ exists target/scala-2.12/src_managed/main/compiled_avro/foo/bar/Protocol.scala
-$ delete target/scala-2.12/classes/domain/Domain.avdl
-$ delete target/scala-2.12/classes/protocol/Protocol.avdl
-$ delete target/scala-2.12/src_managed/main/compiled_avro/foo/bar/Domain.scala
-$ delete target/scala-2.12/src_managed/main/compiled_avro/foo/bar/Protocol.scala

--- a/modules/srcgen/plugin/src/sbt-test/sbt-mu-srcgen/srcGenFromJars/build.sbt
+++ b/modules/srcgen/plugin/src/sbt-test/sbt-mu-srcgen/srcGenFromJars/build.sbt
@@ -6,20 +6,16 @@ lazy val domain = project
   .settings(
     Seq(
       organization := "foo.bar",
-      organizationName := "Foo Bar",
-      scalaVersion := "2.12.4"
+      scalaVersion := "2.12.10"
     ))
   .settings(version := "1.0.0")
   .settings(Seq(
-    publishMavenStyle := true,
     mappings in (Compile, packageBin) ~= { _.filter(!_._1.getName.endsWith(".class")) },
     muSrcGenIdlType := IdlType.Avro,
     muSrcGenSourceDirs := Seq((Compile / resourceDirectory).value),
-    muSrcGenTargetDir := (Compile / sourceManaged).value / "compiled_avro",
-    sourceGenerators in Compile += (Compile / muSrcGen).taskValue,
+    muSrcGenTargetDir := (Compile / sourceManaged).value / "generated_from_avro",
     libraryDependencies ++= Seq(
-      "io.higherkindness"    %% "mu-rpc-channel" % sys.props("version"),
-      "com.chuusai" %% "shapeless" % "2.3.2"
+      "io.higherkindness" %% "mu-rpc-channel" % sys.props("version")
     )
   ))
 
@@ -31,10 +27,8 @@ lazy val root = project
     muSrcGenIdlType := IdlType.Avro,
     muSrcGenJarNames := Seq("domain"),
     muSrcGenIdlTargetDir := (Compile / sourceManaged).value / "avro",
-    muSrcGenTargetDir := (Compile / sourceManaged).value / "compiled_avro",
-    sourceGenerators in Compile += (Compile / muSrcGen).taskValue,
+    muSrcGenTargetDir := (Compile / sourceManaged).value / "generated_from_avro",
     libraryDependencies ++= Seq(
-      "foo.bar" %% "domain" % "1.0.0",
-      "io.higherkindness" %% "mu-rpc-server" % sys.props("version")
+      "foo.bar" %% "domain" % "1.0.0"
     )
   ))

--- a/modules/srcgen/plugin/src/sbt-test/sbt-mu-srcgen/srcGenFromJars/test
+++ b/modules/srcgen/plugin/src/sbt-test/sbt-mu-srcgen/srcGenFromJars/test
@@ -1,8 +1,7 @@
 > domain/compile
-$ exists domain/target/scala-2.12/src_managed/main/compiled_avro/foo/bar/Hello.scala
+$ exists domain/target/scala-2.12/src_managed/main/generated_from_avro/foo/bar/Hello.scala
 > domain/publishLocal
 
 > compile
 $ exists target/scala-2.12/src_managed/main/avro/Hello.avdl
-$ exists target/scala-2.12/src_managed/main/compiled_avro/foo/bar/Hello.scala
-$ delete target/scala-2.12/src_managed/main/compiled_avro/foo/bar/Hello.scala
+$ exists target/scala-2.12/src_managed/main/generated_from_avro/foo/bar/Hello.scala

--- a/modules/srcgen/plugin/src/sbt-test/sbt-mu-srcgen/srcOpenApiGenFromDirs/build.sbt
+++ b/modules/srcgen/plugin/src/sbt-test/sbt-mu-srcgen/srcOpenApiGenFromDirs/build.sbt
@@ -15,12 +15,9 @@ lazy val root = project
   .settings(name := "root")
   .settings(version := "1.0.0")
   .settings(Seq(
-    publishMavenStyle := true,
-    mappings in (Compile, packageBin) ~= { _.filter(!_._1.getName.endsWith(".class")) },
     muSrcGenIdlType := IdlType.OpenAPI,
     muSrcGenSourceDirs := Seq((Compile / resourceDirectory).value),
     muSrcGenTargetDir := (Compile / sourceManaged).value / "compiled_openapi",
-    sourceGenerators in Compile += (Compile / muSrcGen).taskValue,
     muSrcGenOpenApiHttpImpl := higherkindness.mu.rpc.srcgen.openapi.OpenApiSrcGenerator.HttpImpl.Http4sV20,
     addCompilerPlugin("org.scalamacros" % "paradise" % "2.1.1" cross CrossVersion.patch),
     libraryDependencies ++= Seq(

--- a/modules/srcgen/plugin/src/sbt-test/sbt-mu-srcgen/srcProtoGenFromDirs/build.sbt
+++ b/modules/srcgen/plugin/src/sbt-test/sbt-mu-srcgen/srcProtoGenFromDirs/build.sbt
@@ -5,7 +5,6 @@ lazy val root = project
   .settings(
     muSrcGenIdlType := IdlType.Proto,
     muSrcGenTargetDir := (Compile / sourceManaged).value / "compiled_proto",
-    sourceGenerators in Compile += (Compile / muSrcGen).taskValue,
     addCompilerPlugin("org.scalamacros" % "paradise" % "2.1.1" cross CrossVersion.patch),
     libraryDependencies ++= Seq(
         "io.higherkindness"    %% "mu-rpc-channel" % sys.props("version"),

--- a/modules/srcgen/plugin/src/sbt-test/sbt-mu-srcgen/srcProtoGenMonix/build.sbt
+++ b/modules/srcgen/plugin/src/sbt-test/sbt-mu-srcgen/srcProtoGenMonix/build.sbt
@@ -5,8 +5,7 @@ lazy val root = project
   .in(file("."))
   .settings(
     muSrcGenIdlType := IdlType.Proto,
-    muSrcGenTargetDir := (Compile / sourceManaged).value / "compiled_proto",
-    sourceGenerators in Compile += (Compile / muSrcGen).taskValue,
+    muSrcGenTargetDir := (Compile / sourceManaged).value / "generated_from_proto",
     muSrcGenStreamingImplementation := MonixObservable,
     addCompilerPlugin("org.scalamacros" % "paradise" % "2.1.1" cross CrossVersion.patch),
     libraryDependencies ++= Seq(

--- a/modules/srcgen/plugin/src/sbt-test/sbt-mu-srcgen/srcProtoGenMonix/test
+++ b/modules/srcgen/plugin/src/sbt-test/sbt-mu-srcgen/srcProtoGenMonix/test
@@ -1,3 +1,3 @@
 > compile
-$ exists target/scala-2.12/src_managed/main/compiled_proto/com/proto/author.scala
-$ exists target/scala-2.12/src_managed/main/compiled_proto/com/proto/book.scala
+$ exists target/scala-2.12/src_managed/main/generated_from_proto/com/proto/author.scala
+$ exists target/scala-2.12/src_managed/main/generated_from_proto/com/proto/book.scala


### PR DESCRIPTION
I'm working on the documentation at the moment, and noticed this while I was going through a tutorial.

It doesn't really make sense *not* to add the task to the list of sourceGenerators, as the list of generated source files would not be added to `managedSources`. That means even if you ran `muSrcGen` manually and then ran `compile`, the generated source files would not be compiled.

Updated the plugin to automatically register the `muSrcGen` task as a sourceGenerator, and updated the misleading guidance in the documentation.


## What this does?
_Changes, features, fixes ..._

## Checklist

- [ ] Reviewed the diff to look for typos, println and format errors.
- [ ] Updated the docs accordingly.