### PR TITLE
Fixes sbt Plugin Publish

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -57,7 +57,7 @@ jobs:
         - sbt ++$TRAVIS_SCALA_VERSION srcgen-sbt/test
         - sbt ++$TRAVIS_SCALA_VERSION publishLocal srcgen-sbt/publishLocal srcgen-sbt/scripted
     - stage: deploy
-      scala: 2.13.1
+      scala: 2.12.10
       if: branch = master AND type != pull_request AND env(SKIP_SBT_DEPLOY) = false
       name: "Publish sbt plugin"
       script:


### PR DESCRIPTION
## What this do?

Sbt plugins can only be compiled with Scala 2.12.10. This PR fixes it in the Travis CI pipeline.

## Checklist

- [x] Reviewed the diff to look for typos, println and format errors.
- [x] Updated the docs accordingly.

