### PR TITLE
Remove unnecessary publishLocal before running scripted tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -55,7 +55,7 @@ jobs:
       script:
         - sbt ++$TRAVIS_SCALA_VERSION srcgen-core/test
         - sbt ++$TRAVIS_SCALA_VERSION srcgen-sbt/test
-        - sbt ++$TRAVIS_SCALA_VERSION publishLocal srcgen-sbt/publishLocal srcgen-sbt/scripted
+        - sbt ++$TRAVIS_SCALA_VERSION srcgen-sbt/scripted
     - stage: deploy
       scala: 2.12.10
       if: branch = master AND type != pull_request AND env(SKIP_SBT_DEPLOY) = false

--- a/build.sbt
+++ b/build.sbt
@@ -235,7 +235,7 @@ lazy val `srcgen-sbt` = project
         channel / publishLocal,
         server / publishLocal,
         `internal-fs2` / publishLocal,
-        fs2 / publishLocal,
+        `internal-monix` / publishLocal,
         `marshallers-jodatime` / publishLocal,
         `srcgen-core` / publishLocal
       )

--- a/modules/srcgen/plugin/src/sbt-test/sbt-mu-srcgen/srcProtoGenFromDirs/build.sbt
+++ b/modules/srcgen/plugin/src/sbt-test/sbt-mu-srcgen/srcProtoGenFromDirs/build.sbt
@@ -8,6 +8,6 @@ lazy val root = project
     addCompilerPlugin("org.scalamacros" % "paradise" % "2.1.1" cross CrossVersion.patch),
     libraryDependencies ++= Seq(
         "io.higherkindness"    %% "mu-rpc-channel" % sys.props("version"),
-        "io.higherkindness"    %% "mu-rpc-fs2" % sys.props("version")
+        "io.higherkindness"    %% "mu-rpc-internal-fs2" % sys.props("version")
     )
   )

--- a/modules/srcgen/plugin/src/sbt-test/sbt-mu-srcgen/srcProtoGenMonix/build.sbt
+++ b/modules/srcgen/plugin/src/sbt-test/sbt-mu-srcgen/srcProtoGenMonix/build.sbt
@@ -10,6 +10,6 @@ lazy val root = project
     addCompilerPlugin("org.scalamacros" % "paradise" % "2.1.1" cross CrossVersion.patch),
     libraryDependencies ++= Seq(
         "io.higherkindness"    %% "mu-rpc-channel" % sys.props("version"),
-        "io.higherkindness"    %% "mu-rpc-monix" % sys.props("version")
+        "io.higherkindness"    %% "mu-rpc-internal-monix" % sys.props("version")
     )
   )


### PR DESCRIPTION
This shaves a couple of minutes off the Travis build. The sbt plugin tests are the slowest job in the build.


## What this does?
_Changes, features, fixes ..._

## Checklist

- [ ] Reviewed the diff to look for typos, println and format errors.
- [ ] Updated the docs accordingly.