### PR TITLE
Add methods with Resource to GrpcServer and ManagedChannelInterpreter

### DIFF
--- a/modules/channel/src/main/scala/higherkindness/mu/rpc/channel/ManagedChannelInterpreter.scala
+++ b/modules/channel/src/main/scala/higherkindness/mu/rpc/channel/ManagedChannelInterpreter.scala
@@ -17,7 +17,7 @@
 package higherkindness.mu.rpc
 package channel
 
-import cats.effect.{Effect, Sync}
+import cats.effect.{Effect, Resource, Sync}
 import cats.syntax.flatMap._
 import cats.syntax.functor._
 
@@ -52,4 +52,6 @@ class ManagedChannelInterpreter[F[_]](
   def unsafeBuild[T <: ManagedChannelBuilder[T]](implicit E: Effect[F]): ManagedChannel =
     E.toIO(build).unsafeRunSync()
 
+  def resource[T <: ManagedChannelBuilder[T]]: Resource[F, ManagedChannel] =
+    Resource.make(build)(c => F.delay(c.shutdown()).void)
 }

--- a/modules/server/src/main/scala/higherkindness/mu/rpc/server/GrpcServer.scala
+++ b/modules/server/src/main/scala/higherkindness/mu/rpc/server/GrpcServer.scala
@@ -18,7 +18,7 @@ package higherkindness.mu.rpc
 package server
 
 import cats.~>
-import cats.effect.{Effect, IO, Sync}
+import cats.effect.{Async, Effect, IO, Resource, Sync}
 import cats.instances.either._
 import cats.syntax.apply._
 import cats.syntax.flatMap._
@@ -79,17 +79,11 @@ trait GrpcServer[F[_]] { self =>
 
 object GrpcServer {
 
-  def server[F[_]](S: GrpcServer[F])(implicit F: Effect[F]): F[Unit] = {
+  def server[F[_]](S: GrpcServer[F])(implicit F: Effect[F]): F[Unit] =
+    F.bracket(S.start)(_ => F.never[Unit])(_ => S.shutdown >> S.awaitTermination)
 
-    def shutdownEventually(endProcess: Either[Throwable, Unit] => Unit): Unit = {
-      Runtime.getRuntime.addShutdownHook(new Thread() {
-        override def run(): Unit =
-          F.runAsync(S.shutdown *> S.awaitTermination)(cb => IO(endProcess(cb.void))).unsafeRunSync
-      })
-    }
-
-    S.start() *> F.async[Unit](cb => shutdownEventually(cb))
-  }
+  def serverResource[F[_]](S: GrpcServer[F])(implicit F: Async[F]): Resource[F, Unit] =
+    Resource.make(S.start >> F.never)(_ => S.shutdown >> S.awaitTermination)
 
   def default[F[_]](port: Int, configList: List[GrpcConfig])(
       implicit F: Sync[F]

--- a/modules/server/src/main/scala/higherkindness/mu/rpc/server/GrpcServer.scala
+++ b/modules/server/src/main/scala/higherkindness/mu/rpc/server/GrpcServer.scala
@@ -18,9 +18,7 @@ package higherkindness.mu.rpc
 package server
 
 import cats.~>
-import cats.effect.{Async, Effect, IO, Resource, Sync}
-import cats.instances.either._
-import cats.syntax.apply._
+import cats.effect.{Async, Effect, Resource, Sync}
 import cats.syntax.flatMap._
 import cats.syntax.functor._
 import io.grpc.{Server, ServerBuilder, ServerServiceDefinition}
@@ -83,7 +81,7 @@ object GrpcServer {
     F.bracket(S.start)(_ => F.never[Unit])(_ => S.shutdown >> S.awaitTermination)
 
   def serverResource[F[_]](S: GrpcServer[F])(implicit F: Async[F]): Resource[F, Unit] =
-    Resource.make(S.start >> F.never)(_ => S.shutdown >> S.awaitTermination)
+    Resource.make(S.start >> F.never[Unit])(_ => S.shutdown >> S.awaitTermination)
 
   def default[F[_]](port: Int, configList: List[GrpcConfig])(
       implicit F: Sync[F]


### PR DESCRIPTION
## What this does?

Add a method to `GrpcServer` and `ManagedChannelInterpreter` returning a `Resource` for shutting down the server/channel.

## Checklist

- [ ] Reviewed the diff to look for typos, println and format errors.
- [ ] Updated the docs accordingly.

