### PR TITLE
Release 0.21.0

### DIFF
--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "0.21.0-SNAPSHOT"
+version in ThisBuild := "0.21.0"


### PR DESCRIPTION
We haven't released in a while, and we are currently blocking people from upgrading to Scala 2.13.

Highlights of this release:
* Scala 2.13 cross-build
* New design for the microsite
* Rewrite the docs
* Automatically register muSrcGen as a sourceGenerator
* [breaking change] Remove the `@message` annotation
* [breaking change] Introduce sum types for `idlType` and `serializationType` sbt settings
* [breaking change] Remove IDL generation feature
* [breaking change] Rename the sbt plugin from `sbt-mu-idlgen` to `sbt-mu-srcgen`
* [breaking change] Rename the sbt plugin's keys for consistency

I'd also like to include #830 in this release. Just waiting for Peter to confirm he is happy to merge it.