### PR TITLE
Release 0.21.1

### DIFF
--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "0.21.1-SNAPSHOT"
+version in ThisBuild := "0.21.1"


### PR DESCRIPTION
Because the 0.21.0 release accidentally published only the Scala 2.13 artifacts.


## What this does?
_Changes, features, fixes ..._

## Checklist

- [ ] Reviewed the diff to look for typos, println and format errors.
- [ ] Updated the docs accordingly.