### PR TITLE
Fix "method too large" error

### DIFF
--- a/modules/internal/src/main/scala/higherkindness/mu/rpc/internal/serviceImpl.scala
+++ b/modules/internal/src/main/scala/higherkindness/mu/rpc/internal/serviceImpl.scala
@@ -695,8 +695,6 @@ object serviceImpl {
       case _ => sys.error("@service-annotated definition must be a trait or abstract class")
     }
 
-    //println(show(result))
-
     c.Expr(Block(result, Literal(Constant(()))))
   }
 }


### PR DESCRIPTION
Refactors the macro-generated code to avoid generating giant method bodies.

Before the fix, the `@service` macro would generate the following code for the `bindService` method:

```scala
def bindService(...) =
  higherkindness.mu.rpc.internal.service.GRPCServiceDefBuilder.build[F](
    "fully.qualified.ServiceName",
    (FooMethodDescriptor, io.grpc.stub.ServerCalls.asyncUnaryCall(higherkindness.mu.rpc.internal.server.unaryCalls.unaryMethod(algebra.foo, None))),
    (BarMethodDescriptor, io.grpc.stub.ServerCalls.asyncUnaryCall(higherkindness.mu.rpc.internal.server.unaryCalls.unaryMethod(algebra.bar, None))),
    ...
  )
```

One tuple is added for each endpoint `Foo`, `Bar`, ... in the service.

The problem is that `FooMethodDescriptor` is a call to a (macro-generated) method which looks like:

```scala
def FooMethodDescriptor(implicit
  ReqM: io.grpc.MethodDescriptor.Marshaller[FooRequest],
  RespM: io.grpc.MethodDescriptor.Marshaller[FooResponse]
): ...
```

When the macro-generated code is compiled, the implicits are expanded. Because these marshallers are auto-derived using avro4s or PBDirect, the resulting reified code can be huge, and that huge chunk of bytecode ends up inside the body of `bindService`. This can lead to `Method too large` errors when emitting the bytecode.

Fixed by refactoring the generated code. It now looks like:

```scala
object MyService {

  object FooMethodDescriptor {
    def methodDescriptor(implicit reqM: ..., respM: ...): ...
    val _methodDescriptor = methodDescriptor
  }

  object BarMethodDescriptor {
    def methodDescriptor(implicit reqM: ..., respM: ...): ...
    val _methodDescriptor = methodDescriptor
  }

  ...

  def bindService(...) =
    higherkindness.mu.rpc.internal.service.GRPCServiceDefBuilder.build[F](
      "fully.qualified.ServiceName",
      (FooMethodDescriptor._methodDescriptor, ...),
      (BarMethodDescriptor._methodDescriptor, ...),
      ...
    )

}
```

This way the huge chunks of reified code end up inside the static initializers of the `MyService$FooMethodDescriptor$` and `MyService$BarMethodDescriptor$` classes instead of inside the body of `bindService`.

It's still possible to run into the `Method too large` error if the models are really big and deeply nested, but this gives us a bit of breathing space because the code has been split up by endpoint.
