### PR TITLE
muSrcGenIdlType Tweak

### DIFF
--- a/docs/src/main/docs/guides/index.md
+++ b/docs/src/main/docs/guides/index.md
@@ -10,6 +10,6 @@ permalink: guides
 These guides are aimed at developers who are already familiar with Mu-Scala.
 
 If you are new to Mu-Scala, we recommend you read the [Getting Started
-guide](../getting-started) and the [tutorials](../tutorials).
+guide](getting-started) and the [tutorials](tutorials).
 
 Each guide introduces a single feature of Mu-Scala and explains how to use it.

--- a/docs/src/main/docs/tutorials/index.md
+++ b/docs/src/main/docs/tutorials/index.md
@@ -13,8 +13,8 @@ We recommend you read them in roughly the order they appear in the navigation
 menu.
 
 Before starting the tutorials, we recommend you read the [Getting Started
-guide](../getting-started).
+guide](getting-started).
 
 If you are already familiar with Mu-Scala, you may want to read about how to use
-its more advanced features in the [How-To Guides](../guides).
+its more advanced features in the [How-To Guides](guides).
 

--- a/modules/srcgen/core/src/main/scala/higherkindness/mu/rpc/srcgen/GeneratorApplication.scala
+++ b/modules/srcgen/core/src/main/scala/higherkindness/mu/rpc/srcgen/GeneratorApplication.scala
@@ -35,25 +35,20 @@ class GeneratorApplication[T <: Generator](generators: T*) {
       serializationType: SerializationType,
       inputFiles: Set[File],
       outputDir: File
-  ): Seq[File] = {
-    validate(
-      idlTypes.contains(idlType),
-      s"Unknown IDL type '$idlType'. Valid values: ${idlTypes.mkString(", ")}"
-    )
-    generatorsByType(idlType).generateFrom(inputFiles, serializationType).map {
-      case (inputFile, outputFilePath, output) =>
-        val outputFile = new File(outputDir, outputFilePath)
-        logger.info(s"$inputFile -> $outputFile")
-        Option(outputFile.getParentFile).foreach(_.mkdirs())
-        outputFile.write(output)
-        outputFile
-    }
-  }
-
-  private def validate(requirement: Boolean, message: => Any): Unit =
-    if (!requirement) {
-      System.err.println(message)
-      System.exit(1)
+  ): Seq[File] =
+    if (idlTypes.contains(idlType))
+      generatorsByType(idlType).generateFrom(inputFiles, serializationType).map {
+        case (inputFile, outputFilePath, output) =>
+          val outputFile = new File(outputDir, outputFilePath)
+          logger.info(s"$inputFile -> $outputFile")
+          Option(outputFile.getParentFile).foreach(_.mkdirs())
+          outputFile.write(output)
+          outputFile
+      } else {
+      System.out.println(
+        s"Unknown IDL type '$idlType', skipping code generation in this module. " +
+          s"Valid values: ${idlTypes.mkString(", ")}")
+      Seq.empty[File]
     }
 
   // $COVERAGE-ON$

--- a/modules/srcgen/core/src/main/scala/higherkindness/mu/rpc/srcgen/GeneratorApplication.scala
+++ b/modules/srcgen/core/src/main/scala/higherkindness/mu/rpc/srcgen/GeneratorApplication.scala
@@ -44,10 +44,12 @@ class GeneratorApplication[T <: Generator](generators: T*) {
           Option(outputFile.getParentFile).foreach(_.mkdirs())
           outputFile.write(output)
           outputFile
-      } else {
+      }
+    else {
       System.out.println(
         s"Unknown IDL type '$idlType', skipping code generation in this module. " +
-          s"Valid values: ${idlTypes.mkString(", ")}")
+          s"Valid values: ${idlTypes.mkString(", ")}"
+      )
       Seq.empty[File]
     }
 


### PR DESCRIPTION
## What this does?

Currently, the `sbt-mu-srcgen` requires the sbt setting `muSrcGenIdlType` with a value different from the default one: `Unknown`. This happens even for those sbt projects or submodules that have no protocols to generate sources from.

```
Unknown IDL type 'Unknown'. Valid values: Proto, Avro, OpenAPI
```

As a workaround, the user can set up any of the valid values but it's not quite user-friendly.

In this PR, I'm removing the existing validation and changing it by simple check if-else. If the module has a "valid" `muSrcGenIdlType`, the plugin will run the code generator, and, in any other case, the plugin will return an empty list and, an informative message for the user.

Additionally, I'm fixing a couple of broken links in the docs.

## Checklist

- [x] Reviewed the diff to look for typos, println and format errors.
- [x] Updated the docs accordingly.

