### PR TITLE
Support compression on server side with FS2 streaming

### DIFF
--- a/modules/internal/fs2/src/main/scala/higherkindness/mu/client/fs2Calls.scala
+++ b/modules/internal/fs2/src/main/scala/higherkindness/mu/client/fs2Calls.scala
@@ -14,9 +14,7 @@
  * limitations under the License.
  */
 
-package higherkindness.mu.rpc
-package internal
-package client
+package higherkindness.mu.rpc.internal.client
 
 import cats.effect.ConcurrentEffect
 import cats.syntax.flatMap._

--- a/modules/internal/fs2/src/main/scala/higherkindness/mu/server/fs2Calls.scala
+++ b/modules/internal/fs2/src/main/scala/higherkindness/mu/server/fs2Calls.scala
@@ -14,14 +14,13 @@
  * limitations under the License.
  */
 
-package higherkindness.mu.rpc
-package internal
-package server
+package higherkindness.mu.rpc.internal.server
 
 import fs2.Stream
 import cats.effect.ConcurrentEffect
 import io.grpc.ServerCallHandler
 import org.lyranthe.fs2_grpc.java_runtime.server.Fs2ServerCallHandler
+import higherkindness.mu.rpc.protocol.CompressionType
 
 object fs2Calls {
 
@@ -30,25 +29,25 @@ object fs2Calls {
 
   def unaryMethod[F[_]: ConcurrentEffect, Req, Res](
       f: Req => F[Res],
-      maybeCompression: Option[String]
+      compressionType: CompressionType
   ): ServerCallHandler[Req, Res] =
     Fs2ServerCallHandler[F].unaryToUnaryCall[Req, Res]((req, _) => f(req))
 
   def clientStreamingMethod[F[_]: ConcurrentEffect, Req, Res](
       f: Stream[F, Req] => F[Res],
-      maybeCompression: Option[String]
+      compressionType: CompressionType
   ): ServerCallHandler[Req, Res] =
     Fs2ServerCallHandler[F].streamingToUnaryCall[Req, Res]((stream, _) => f(stream))
 
   def serverStreamingMethod[F[_]: ConcurrentEffect, Req, Res](
       f: Req => Stream[F, Res],
-      maybeCompression: Option[String]
+      compressionType: CompressionType
   ): ServerCallHandler[Req, Res] =
     Fs2ServerCallHandler[F].unaryToStreamingCall[Req, Res]((req, _) => f(req))
 
   def bidiStreamingMethod[F[_]: ConcurrentEffect, Req, Res](
       f: Stream[F, Req] => Stream[F, Res],
-      maybeCompression: Option[String]
+      compressionType: CompressionType
   ): ServerCallHandler[Req, Res] =
     Fs2ServerCallHandler[F].streamingToStreamingCall[Req, Res]((stream, _) => f(stream))
 

--- a/modules/internal/src/main/scala/higherkindness/mu/rpc/internal/server/package.scala
+++ b/modules/internal/src/main/scala/higherkindness/mu/rpc/internal/server/package.scala
@@ -19,16 +19,17 @@ package higherkindness.mu.rpc.internal
 import cats.effect.Sync
 import io.grpc.{Status, StatusException, StatusRuntimeException}
 import io.grpc.stub.{ServerCallStreamObserver, StreamObserver}
+import higherkindness.mu.rpc.protocol._
 
 package object server {
 
   private[internal] def addCompression[F[_]: Sync, A](
       observer: StreamObserver[A],
-      algorithm: Option[String]
+      compressionType: CompressionType
   ): F[Unit] =
-    (observer, algorithm) match {
-      case (o: ServerCallStreamObserver[_], Some(alg)) => Sync[F].delay(o.setCompression(alg))
-      case _                                           => Sync[F].unit
+    (observer, compressionType) match {
+      case (o: ServerCallStreamObserver[_], Gzip) => Sync[F].delay(o.setCompression("gzip"))
+      case _                                      => Sync[F].unit
     }
 
   private[internal] def completeObserver[F[_]: Sync, A](

--- a/modules/internal/src/main/scala/higherkindness/mu/rpc/internal/server/unaryCalls.scala
+++ b/modules/internal/src/main/scala/higherkindness/mu/rpc/internal/server/unaryCalls.scala
@@ -20,17 +20,18 @@ import cats.effect.{Effect, IO}
 import cats.syntax.apply._
 import io.grpc.stub.ServerCalls.UnaryMethod
 import io.grpc.stub.StreamObserver
+import higherkindness.mu.rpc.protocol.CompressionType
 
 object unaryCalls {
 
   def unaryMethod[F[_]: Effect, Req, Res](
       f: Req => F[Res],
-      maybeCompression: Option[String]
+      compressionType: CompressionType
   ): UnaryMethod[Req, Res] =
     new UnaryMethod[Req, Res] {
       override def invoke(request: Req, responseObserver: StreamObserver[Res]): Unit = {
         Effect[F]
-          .runAsync(addCompression(responseObserver, maybeCompression) *> f(request)) {
+          .runAsync(addCompression(responseObserver, compressionType) *> f(request)) {
             completeObserver[IO, Res](responseObserver)
           }
           .toIO


### PR DESCRIPTION
* Make use of the compression option in `fs2Calls` (it was ignored until now)
* Refactor to pass the compression type as a proper ADT type instead of a string
* Slight tidy-up of the service macro implementation
* Enable compression on client side for compression tests
* Stop using `ConcurrentMonad` type alias in tests because it caused really long lines that messed up the formatting


