### PR TITLE
Avro Mu-Haskell integration tests

### DIFF
--- a/modules/haskell-integration-tests/mu-haskell-client-server/Setup.hs
+++ b/modules/haskell-integration-tests/mu-haskell-client-server/Setup.hs
@@ -1,2 +1,2 @@
-import Distribution.Simple
+import           Distribution.Simple
 main = defaultMain

--- a/modules/haskell-integration-tests/mu-haskell-client-server/avro-client/Main.hs
+++ b/modules/haskell-integration-tests/mu-haskell-client-server/avro-client/Main.hs
@@ -1,0 +1,72 @@
+{-# language DataKinds             #-}
+{-# language FlexibleContexts      #-}
+{-# language PartialTypeSignatures #-}
+{-# language OverloadedLabels      #-}
+{-# language OverloadedStrings     #-}
+{-# language TypeApplications      #-}
+{-# OPTIONS_GHC -fno-warn-partial-type-signatures #-}
+
+module Main where
+
+import Data.Aeson as A (ToJSON, encode)
+import Data.ByteString.Char8 as BS (unpack)
+import Data.ByteString.Lazy as LBS (toStrict)
+import Data.Functor.Identity
+import Data.List (intercalate)
+import Data.Maybe (fromMaybe)
+import Data.Text as T (Text, pack, unpack)
+import System.Environment (getArgs)
+import Text.Read (readMaybe)
+
+import Mu.Adapter.Json
+import Mu.GRpc.Client.Optics
+import Mu.Schema.Optics
+
+import Network.GRPC.Client
+
+import AvroProtocol
+
+main :: IO ()
+main = do
+  args <- getArgs
+  let config = grpcClientConfigSimple (head args) 9124 False
+  Right conn <- initGRpc config msgAvro @WeatherService
+  case (tail args) of
+    ["ping"] -> ping conn
+    ["get-forecast", city, days] -> getForecast conn city days
+    _ -> putStrLn "Invalid args"
+
+ping :: GRpcConnection WeatherService 'MsgAvro -> IO ()
+ping client = do
+  client ^. #ping
+  putStrLn "pong"
+
+getForecast :: GRpcConnection WeatherService 'MsgAvro -> String -> String -> IO ()
+getForecast client city days = do
+  GRpcOk resp <- (client ^. #getForecast) req
+  putStrLn $ showGetForecastResponse resp
+    where
+      c = T.pack city
+      d = fromMaybe 5 $ readMaybe days
+      req = record (c, d)
+
+  {-
+getForecast :: GRpcConnection WeatherService 'MsgAvro -> String -> String -> IO ()
+getForecast client city days = do
+  GRpcOk resp <- (client ^. #getForecast) req
+  putStrLn $ showGetForecastResponse resp
+    where
+      c = T.pack city
+      d = fromMaybe 5 $ readMaybe days
+      req = record (c, d)
+  -}
+
+showGetForecastResponse :: GetForecastResponse -> String
+showGetForecastResponse resp =
+  lastUpdated ++ " " ++ dailyForecasts
+    where
+      lastUpdated = T.unpack(resp ^. #last_updated)
+      dailyForecasts = toJsonString (resp ^. #daily_forecasts)
+
+toJsonString :: A.ToJSON a => a -> String
+toJsonString = BS.unpack . LBS.toStrict . A.encode

--- a/modules/haskell-integration-tests/mu-haskell-client-server/avro-client/Main.hs
+++ b/modules/haskell-integration-tests/mu-haskell-client-server/avro-client/Main.hs
@@ -8,65 +8,63 @@
 
 module Main where
 
-import Data.Aeson as A (ToJSON, encode)
-import Data.ByteString.Char8 as BS (unpack)
-import Data.ByteString.Lazy as LBS (toStrict)
-import Data.Functor.Identity
-import Data.List (intercalate)
-import Data.Maybe (fromMaybe)
-import Data.Text as T (Text, pack, unpack)
-import System.Environment (getArgs)
-import Text.Read (readMaybe)
+import           Data.Aeson                    as A
+                                                ( ToJSON
+                                                , encode
+                                                )
+import           Data.ByteString.Char8         as BS
+                                                ( unpack )
+import           Data.ByteString.Lazy          as LBS
+                                                ( toStrict )
+import           Data.Functor.Identity
+import           Data.List                      ( intercalate )
+import           Data.Maybe                     ( fromMaybe )
+import           Data.Text                     as T
+                                                ( Text
+                                                , pack
+                                                , unpack
+                                                )
+import           System.Environment             ( getArgs )
+import           Text.Read                      ( readMaybe )
 
-import Mu.Adapter.Json
-import Mu.GRpc.Client.Optics
-import Mu.Schema.Optics
+import           Mu.Adapter.Json
+import           Mu.GRpc.Client.Optics
+import           Mu.Schema.Optics
 
-import Network.GRPC.Client
+import           Network.GRPC.Client
 
-import AvroProtocol
+import           AvroProtocol
 
 main :: IO ()
 main = do
   args <- getArgs
   let config = grpcClientConfigSimple (head args) 9124 False
   Right conn <- initGRpc config msgAvro @WeatherService
-  case (tail args) of
-    ["ping"] -> ping conn
+  case tail args of
+    ["ping"]                     -> ping conn
     ["get-forecast", city, days] -> getForecast conn city days
-    _ -> putStrLn "Invalid args"
+    _                            -> putStrLn "Invalid args"
 
 ping :: GRpcConnection WeatherService 'MsgAvro -> IO ()
 ping client = do
   client ^. #ping
   putStrLn "pong"
 
-getForecast :: GRpcConnection WeatherService 'MsgAvro -> String -> String -> IO ()
+getForecast
+  :: GRpcConnection WeatherService 'MsgAvro -> String -> String -> IO ()
 getForecast client city days = do
   GRpcOk resp <- (client ^. #getForecast) req
   putStrLn $ showGetForecastResponse resp
-    where
-      c = T.pack city
-      d = fromMaybe 5 $ readMaybe days
-      req = record (c, d)
-
-  {-
-getForecast :: GRpcConnection WeatherService 'MsgAvro -> String -> String -> IO ()
-getForecast client city days = do
-  GRpcOk resp <- (client ^. #getForecast) req
-  putStrLn $ showGetForecastResponse resp
-    where
-      c = T.pack city
-      d = fromMaybe 5 $ readMaybe days
-      req = record (c, d)
-  -}
+ where
+  c   = T.pack city
+  d   = fromMaybe 5 $ readMaybe days
+  req = record (c, d)
 
 showGetForecastResponse :: GetForecastResponse -> String
-showGetForecastResponse resp =
-  lastUpdated ++ " " ++ dailyForecasts
-    where
-      lastUpdated = T.unpack(resp ^. #last_updated)
-      dailyForecasts = toJsonString (resp ^. #daily_forecasts)
+showGetForecastResponse resp = lastUpdated ++ " " ++ dailyForecasts
+ where
+  lastUpdated    = T.unpack (resp ^. #last_updated)
+  dailyForecasts = toJsonString (resp ^. #daily_forecasts)
 
 toJsonString :: A.ToJSON a => a -> String
 toJsonString = BS.unpack . LBS.toStrict . A.encode

--- a/modules/haskell-integration-tests/mu-haskell-client-server/avro-server/Main.hs
+++ b/modules/haskell-integration-tests/mu-haskell-client-server/avro-server/Main.hs
@@ -1,0 +1,41 @@
+{-# language DataKinds             #-}
+{-# language FlexibleContexts      #-}
+{-# language PartialTypeSignatures #-}
+{-# language OverloadedLabels      #-}
+{-# language OverloadedStrings     #-}
+{-# language TypeApplications      #-}
+{-# OPTIONS_GHC -fno-warn-partial-type-signatures #-}
+
+module Main where
+
+import Data.Functor.Identity
+import Data.Maybe (fromMaybe)
+import Data.Text as T (Text)
+import Mu.GRpc.Server
+import Mu.Server
+import Mu.Schema.Optics
+
+import AvroProtocol
+
+main :: IO ()
+main = runGRpcApp msgAvro 9124 server
+
+ping :: (MonadServer m) => m ()
+ping = return ()
+
+getForecast :: (MonadServer m) => GetForecastRequest -> m GetForecastResponse
+getForecast req =
+  return resp
+    where
+      days      = fromIntegral (req ^. #days_required)
+      forecasts = sunnyDays days
+      resp      = record (lastUpdated, forecasts)
+
+lastUpdated :: T.Text
+lastUpdated = "2020-03-20T12:00:00Z"
+
+sunnyDays :: Int -> [Weather]
+sunnyDays n = replicate n (enum @"SUNNY")
+
+server :: (MonadServer m) => ServerT Identity WeatherService m _
+server = Server (getForecast :<|>: ping :<|>: H0)

--- a/modules/haskell-integration-tests/mu-haskell-client-server/avro-server/Main.hs
+++ b/modules/haskell-integration-tests/mu-haskell-client-server/avro-server/Main.hs
@@ -8,14 +8,15 @@
 
 module Main where
 
-import Data.Functor.Identity
-import Data.Maybe (fromMaybe)
-import Data.Text as T (Text)
-import Mu.GRpc.Server
-import Mu.Server
-import Mu.Schema.Optics
+import           Data.Functor.Identity
+import           Data.Maybe                     ( fromMaybe )
+import           Data.Text                     as T
+                                                ( Text )
+import           Mu.GRpc.Server
+import           Mu.Server
+import           Mu.Schema.Optics
 
-import AvroProtocol
+import           AvroProtocol
 
 main :: IO ()
 main = runGRpcApp msgAvro 9124 server
@@ -24,12 +25,11 @@ ping :: (MonadServer m) => m ()
 ping = return ()
 
 getForecast :: (MonadServer m) => GetForecastRequest -> m GetForecastResponse
-getForecast req =
-  return resp
-    where
-      days      = fromIntegral (req ^. #days_required)
-      forecasts = sunnyDays days
-      resp      = record (lastUpdated, forecasts)
+getForecast req = return resp
+ where
+  days      = fromIntegral (req ^. #days_required)
+  forecasts = sunnyDays days
+  resp      = record (lastUpdated, forecasts)
 
 lastUpdated :: T.Text
 lastUpdated = "2020-03-20T12:00:00Z"

--- a/modules/haskell-integration-tests/mu-haskell-client-server/mu-haskell-client-server.cabal
+++ b/modules/haskell-integration-tests/mu-haskell-client-server/mu-haskell-client-server.cabal
@@ -12,15 +12,46 @@ cabal-version:       >=1.10
 
 library
   hs-source-dirs:      protocol
-  exposed-modules:     Protocol
+  exposed-modules:     ProtobufProtocol
+                     , AvroProtocol
   default-language:    Haskell2010
   build-depends:       base >= 4.12 && < 5
                      , text
                      , mu-schema >= 0.2.0
                      , mu-optics >= 0.2.0
                      , mu-rpc >= 0.2.0
+                     , mu-avro >= 0.2.0
                      , mu-protobuf >= 0.2.0
+
+executable avro-server
+  hs-source-dirs:      avro-server
+  main-is:             Main.hs
+  default-language:    Haskell2010
+  build-depends:       base >= 4.12 && < 5
+                     , text
+                     , mu-schema >= 0.2.0
+                     , mu-optics >= 0.2.0
+                     , mu-rpc >= 0.2.0
+                     , mu-avro >= 0.2.0
                      , mu-grpc-server >= 0.2.0
+                     , mu-haskell-client-server
+
+executable avro-client
+  hs-source-dirs:      avro-client
+  main-is:             Main.hs
+  default-language:    Haskell2010
+  build-depends:       base >= 4.12 && < 5
+                     , text
+                     , aeson >= 1.4.6.0
+                     , bytestring >= 0.10.8.2
+                     , mu-schema >= 0.2.0
+                     , mu-optics >= 0.2.0
+                     , mu-rpc >= 0.2.0
+                     , mu-avro >= 0.2.0
+                     , mu-grpc-client >= 0.2.0
+                     , http2-client-grpc >= 0.8.0.0
+                     , mu-haskell-client-server
+
 executable protobuf-server
   hs-source-dirs:      protobuf-server
   main-is:             Main.hs

--- a/modules/haskell-integration-tests/mu-haskell-client-server/protobuf-client/Main.hs
+++ b/modules/haskell-integration-tests/mu-haskell-client-server/protobuf-client/Main.hs
@@ -8,76 +8,91 @@
 
 module Main where
 
-import Data.Aeson as A (ToJSON, encode)
-import Data.ByteString.Char8 as BS (unpack)
-import Data.ByteString.Lazy as LBS (toStrict)
-import Data.Conduit
-import qualified Data.Conduit.Combinators as C
-import Data.List (intercalate)
-import Data.Maybe (fromMaybe)
-import Data.Text as T (Text, pack, unpack)
-import System.Environment (getArgs)
-import Text.Read (readMaybe)
+import           Data.Aeson                    as A
+                                                ( ToJSON
+                                                , encode
+                                                )
+import           Data.ByteString.Char8         as BS
+                                                ( unpack )
+import           Data.ByteString.Lazy          as LBS
+                                                ( toStrict )
+import           Data.Conduit
+import qualified Data.Conduit.Combinators      as C
+import           Data.List                      ( intercalate )
+import           Data.Maybe                     ( fromMaybe )
+import           Data.Text                     as T
+                                                ( Text
+                                                , pack
+                                                , unpack
+                                                )
+import           System.Environment             ( getArgs )
+import           Text.Read                      ( readMaybe )
 
-import Mu.Adapter.Json
-import Mu.GRpc.Client.Optics
-import Mu.Schema.Optics
+import           Mu.Adapter.Json
+import           Mu.GRpc.Client.Optics
+import           Mu.Schema.Optics
 
-import Network.GRPC.Client
+import           Network.GRPC.Client
 
-import ProtobufProtocol
+import           ProtobufProtocol
 
 main :: IO ()
 main = do
   args <- getArgs
   let config = grpcClientConfigSimple (head args) 9123 False
   Right conn <- initGRpc config msgProtoBuf @WeatherService
-  case (tail args) of
-    ["ping"] -> ping conn
+  case tail args of
+    ["ping"]                     -> ping conn
     ["get-forecast", city, days] -> getForecast conn city days
     ["publish-rain-events", city] -> publishRainEvents conn city
     ["subscribe-to-rain-events", city] -> subscribeToRainEvents conn city
-    _ -> putStrLn "Invalid args"
+    _                            -> putStrLn "Invalid args"
 
 ping :: GRpcConnection WeatherService 'MsgProtoBuf -> IO ()
 ping client = do
   client ^. #ping
   putStrLn "pong"
 
-getForecast :: GRpcConnection WeatherService 'MsgProtoBuf -> String -> String -> IO ()
+getForecast
+  :: GRpcConnection WeatherService 'MsgProtoBuf -> String -> String -> IO ()
 getForecast client city days = do
   GRpcOk resp <- (client ^. #getForecast) req
   putStrLn $ showGetForecastResponse resp
-    where
-      c = Just(T.pack city)
-      d = readMaybe days
-      req = record (c, d)
+ where
+  c   = Just (T.pack city)
+  d   = readMaybe days
+  req = record (c, d)
 
 showGetForecastResponse :: GetForecastResponse -> String
-showGetForecastResponse resp =
-  lastUpdated ++ " " ++ dailyForecasts
-    where
-      lastUpdated = T.unpack(fromMaybe "" (resp ^. #last_updated))
-      dailyForecasts = toJsonString (fromMaybe [] (resp ^. #daily_forecasts))
+showGetForecastResponse resp = lastUpdated ++ " " ++ dailyForecasts
+ where
+  lastUpdated    = T.unpack (fromMaybe "" (resp ^. #last_updated))
+  dailyForecasts = toJsonString (fromMaybe [] (resp ^. #daily_forecasts))
 
-publishRainEvents :: GRpcConnection WeatherService 'MsgProtoBuf -> String -> IO ()
+publishRainEvents
+  :: GRpcConnection WeatherService 'MsgProtoBuf -> String -> IO ()
 publishRainEvents client city = do
   sink        <- (client ^. #publishRainEvents) Compressed
   GRpcOk resp <- runConduit $ stream .| sink
   putStrLn $ showResponse (resp ^. #rained_count)
-    where
-      stream = C.yieldMany events
-      events = toRainEvent <$> [started, stopped, started, stopped, started]
-      toRainEvent x = record (Just $ T.pack city, Just x)
-      showResponse rainedCount = "It started raining " ++ show(fromMaybe 0 rainedCount) ++ " times"
+ where
+  stream = C.yieldMany events
+  events = toRainEvent <$> [started, stopped, started, stopped, started]
+  toRainEvent x = record (Just $ T.pack city, Just x)
+  showResponse rainedCount =
+    "It started raining " ++ show (fromMaybe 0 rainedCount) ++ " times"
 
-subscribeToRainEvents :: GRpcConnection WeatherService 'MsgProtoBuf -> String -> IO ()
+subscribeToRainEvents
+  :: GRpcConnection WeatherService 'MsgProtoBuf -> String -> IO ()
 subscribeToRainEvents client city = do
   source <- (client ^. #subscribeToRainEvents) req
-  runConduit $ source .| C.map (toJsonString . extractEventType) .| C.mapM_ putStrLn
-    where
-      req = record1 $ Just(T.pack city)
-      extractEventType (GRpcOk reply) = reply ^. #event_type
+  runConduit
+    $  source
+    .| C.map (toJsonString . extractEventType)
+    .| C.mapM_ putStrLn
+ where
+  req = record1 $ Just (T.pack city)
+  extractEventType (GRpcOk reply) = reply ^. #event_type
 
 toJsonString :: A.ToJSON a => a -> String
 toJsonString = BS.unpack . LBS.toStrict . A.encode

--- a/modules/haskell-integration-tests/mu-haskell-client-server/protobuf-client/Main.hs
+++ b/modules/haskell-integration-tests/mu-haskell-client-server/protobuf-client/Main.hs
@@ -25,7 +25,7 @@ import Mu.Schema.Optics
 
 import Network.GRPC.Client
 
-import Protocol
+import ProtobufProtocol
 
 main :: IO ()
 main = do

--- a/modules/haskell-integration-tests/mu-haskell-client-server/protobuf-server/Main.hs
+++ b/modules/haskell-integration-tests/mu-haskell-client-server/protobuf-server/Main.hs
@@ -8,17 +8,18 @@
 
 module Main where
 
-import Data.Conduit
-import qualified Data.Conduit.Combinators as C
-import Data.Maybe (fromMaybe)
-import Data.Monoid as M
-import Data.Text as T (Text)
-import           Control.Monad.IO.Class         (liftIO)
-import Mu.GRpc.Server
-import Mu.Server
-import Mu.Schema.Optics
+import           Data.Conduit
+import qualified Data.Conduit.Combinators      as C
+import           Data.Maybe                     ( fromMaybe )
+import           Data.Monoid                   as M
+import           Data.Text                     as T
+                                                ( Text )
+import           Control.Monad.IO.Class         ( liftIO )
+import           Mu.GRpc.Server
+import           Mu.Server
+import           Mu.Schema.Optics
 
-import ProtobufProtocol
+import           ProtobufProtocol
 
 main :: IO ()
 main = runGRpcApp msgProtoBuf 9123 server
@@ -27,12 +28,11 @@ ping :: (MonadServer m) => m ()
 ping = return ()
 
 getForecast :: (MonadServer m) => GetForecastRequest -> m GetForecastResponse
-getForecast req =
-  return resp
-    where
-      days      = fromIntegral $ fromMaybe 5 (req ^. #days_required)
-      forecasts = sunnyDays days
-      resp      = record (Just lastUpdated, Just forecasts)
+getForecast req = return resp
+ where
+  days      = fromIntegral $ fromMaybe 5 (req ^. #days_required)
+  forecasts = sunnyDays days
+  resp      = record (Just lastUpdated, Just forecasts)
 
 lastUpdated :: T.Text
 lastUpdated = "2020-03-20T12:00:00Z"
@@ -40,23 +40,32 @@ lastUpdated = "2020-03-20T12:00:00Z"
 sunnyDays :: Int -> [Weather]
 sunnyDays n = replicate n (enum @"SUNNY")
 
-publishRainEvents :: (MonadServer m) => ConduitT () RainEvent m () -> m RainSummaryResponse
-publishRainEvents source =
-  toResponse <$> countRainStartedEvents
-    where
-      toResponse count = record1 $ Just(fromIntegral(M.getSum count))
-      countRainStartedEvents = runConduit $ source .| C.foldMap countMsg
-      countMsg msg = countEvent $ msg ^. #event_type
-      countEvent (Just x) | x == started = M.Sum 1
-      countEvent _                       = M.Sum 0
+publishRainEvents
+  :: (MonadServer m) => ConduitT () RainEvent m () -> m RainSummaryResponse
+publishRainEvents source = toResponse <$> countRainStartedEvents
+ where
+  toResponse count = record1 $ Just (fromIntegral (M.getSum count))
+  countRainStartedEvents = runConduit $ source .| C.foldMap countMsg
+  countMsg msg = countEvent $ msg ^. #event_type
+  countEvent (Just x) | x == started = M.Sum 1
+  countEvent _                       = M.Sum 0
 
-subscribeToRainEvents :: (MonadServer m) => SubscribeToRainEventsRequest -> ConduitT RainEvent Void m () -> m ()
-subscribeToRainEvents req sink =
-  runConduit $ C.yieldMany events .| sink
-    where
-      events = toRainEvent <$> [started, stopped, started, stopped, started]
-      toRainEvent x = record (city, Just x)
-      city = req ^. #city
+subscribeToRainEvents
+  :: (MonadServer m)
+  => SubscribeToRainEventsRequest
+  -> ConduitT RainEvent Void m ()
+  -> m ()
+subscribeToRainEvents req sink = runConduit $ C.yieldMany events .| sink
+ where
+  events = toRainEvent <$> [started, stopped, started, stopped, started]
+  toRainEvent x = record (city, Just x)
+  city = req ^. #city
 
 server :: (MonadServer m) => ServerT Maybe WeatherService m _
-server = Server (ping :<|>: getForecast :<|>: publishRainEvents :<|>: subscribeToRainEvents :<|>: H0)
+server = Server
+  (     ping
+  :<|>: getForecast
+  :<|>: publishRainEvents
+  :<|>: subscribeToRainEvents
+  :<|>: H0
+  )

--- a/modules/haskell-integration-tests/mu-haskell-client-server/protobuf-server/Main.hs
+++ b/modules/haskell-integration-tests/mu-haskell-client-server/protobuf-server/Main.hs
@@ -18,7 +18,7 @@ import Mu.GRpc.Server
 import Mu.Server
 import Mu.Schema.Optics
 
-import Protocol
+import ProtobufProtocol
 
 main :: IO ()
 main = runGRpcApp msgProtoBuf 9123 server

--- a/modules/haskell-integration-tests/mu-haskell-client-server/protocol/AvroProtocol.hs
+++ b/modules/haskell-integration-tests/mu-haskell-client-server/protocol/AvroProtocol.hs
@@ -1,0 +1,29 @@
+{-# language DataKinds             #-}
+{-# language DeriveAnyClass        #-}
+{-# language DeriveGeneric         #-}
+{-# language DuplicateRecordFields #-}
+{-# language FlexibleContexts      #-}
+{-# language FlexibleInstances     #-}
+{-# language MultiParamTypeClasses #-}
+{-# language PolyKinds             #-}
+{-# language TemplateHaskell       #-}
+{-# language TypeApplications      #-}
+{-# language TypeFamilies          #-}
+{-# language TypeOperators         #-}
+
+module AvroProtocol where
+
+import Data.Functor.Identity
+import GHC.Generics
+
+import Mu.Quasi.Avro
+import Mu.Schema
+import Mu.Schema.Optics
+
+avdl "WeatherProtocol" "WeatherService" "." "weather.avdl"
+
+type GetForecastRequest = Term Identity WeatherProtocol (WeatherProtocol :/: "GetForecastRequest")
+
+type Weather = Term Identity WeatherProtocol (WeatherProtocol :/: "Weather")
+
+type GetForecastResponse = Term Identity WeatherProtocol (WeatherProtocol :/: "GetForecastResponse")

--- a/modules/haskell-integration-tests/mu-haskell-client-server/protocol/AvroProtocol.hs
+++ b/modules/haskell-integration-tests/mu-haskell-client-server/protocol/AvroProtocol.hs
@@ -13,17 +13,19 @@
 
 module AvroProtocol where
 
-import Data.Functor.Identity
-import GHC.Generics
+import           Data.Functor.Identity
+import           GHC.Generics
 
-import Mu.Quasi.Avro
-import Mu.Schema
-import Mu.Schema.Optics
+import           Mu.Quasi.Avro
+import           Mu.Schema
+import           Mu.Schema.Optics
 
 avdl "WeatherProtocol" "WeatherService" "." "weather.avdl"
 
-type GetForecastRequest = Term Identity WeatherProtocol (WeatherProtocol :/: "GetForecastRequest")
+type GetForecastRequest
+  = Term Identity WeatherProtocol (WeatherProtocol :/: "GetForecastRequest")
 
 type Weather = Term Identity WeatherProtocol (WeatherProtocol :/: "Weather")
 
-type GetForecastResponse = Term Identity WeatherProtocol (WeatherProtocol :/: "GetForecastResponse")
+type GetForecastResponse
+  = Term Identity WeatherProtocol (WeatherProtocol :/: "GetForecastResponse")

--- a/modules/haskell-integration-tests/mu-haskell-client-server/protocol/ProtobufProtocol.hs
+++ b/modules/haskell-integration-tests/mu-haskell-client-server/protocol/ProtobufProtocol.hs
@@ -13,24 +13,27 @@
 
 module ProtobufProtocol where
 
-import Data.Text as T
-import GHC.Generics
+import           Data.Text                     as T
+import           GHC.Generics
 
-import Mu.Quasi.GRpc
-import Mu.Schema
-import Mu.Schema.Optics
+import           Mu.Quasi.GRpc
+import           Mu.Schema
+import           Mu.Schema.Optics
 
 grpc "WeatherProtocol" id "weather.proto"
 
-type GetForecastRequest = Term Maybe WeatherProtocol (WeatherProtocol :/: "GetForecastRequest")
+type GetForecastRequest
+  = Term Maybe WeatherProtocol (WeatherProtocol :/: "GetForecastRequest")
 
 type Weather = Term Maybe WeatherProtocol (WeatherProtocol :/: "Weather")
 
-type GetForecastResponse = Term Maybe WeatherProtocol (WeatherProtocol :/: "GetForecastResponse")
+type GetForecastResponse
+  = Term Maybe WeatherProtocol (WeatherProtocol :/: "GetForecastResponse")
 
 type RainEvent = Term Maybe WeatherProtocol (WeatherProtocol :/: "RainEvent")
 
-type RainEventType = Term Maybe WeatherProtocol (WeatherProtocol :/: "RainEventType")
+type RainEventType
+  = Term Maybe WeatherProtocol (WeatherProtocol :/: "RainEventType")
 
 started :: RainEventType
 started = enum @"STARTED"
@@ -38,7 +41,12 @@ started = enum @"STARTED"
 stopped :: RainEventType
 stopped = enum @"STOPPED"
 
-type RainSummaryResponse = Term Maybe WeatherProtocol (WeatherProtocol :/: "RainSummaryResponse")
+type RainSummaryResponse
+  = Term Maybe WeatherProtocol (WeatherProtocol :/: "RainSummaryResponse")
 
-type SubscribeToRainEventsRequest = Term Maybe WeatherProtocol (WeatherProtocol :/: "SubscribeToRainEventsRequest")
+type SubscribeToRainEventsRequest
+  = Term
+      Maybe
+      WeatherProtocol
+      (WeatherProtocol :/: "SubscribeToRainEventsRequest")
 

--- a/modules/haskell-integration-tests/mu-haskell-client-server/protocol/ProtobufProtocol.hs
+++ b/modules/haskell-integration-tests/mu-haskell-client-server/protocol/ProtobufProtocol.hs
@@ -11,7 +11,7 @@
 {-# language TypeFamilies          #-}
 {-# language TypeOperators         #-}
 
-module Protocol where
+module ProtobufProtocol where
 
 import Data.Text as T
 import GHC.Generics

--- a/modules/haskell-integration-tests/mu-haskell-client-server/weather.avdl
+++ b/modules/haskell-integration-tests/mu-haskell-client-server/weather.avdl
@@ -1,0 +1,24 @@
+@namespace("integrationtest")
+protocol WeatherService {
+
+  record GetForecastRequest {
+    string city;
+    int days_required;
+  }
+
+  enum Weather {
+    SUNNY,
+    CLOUDY,
+    RAINY
+  }
+
+  record GetForecastResponse {
+    string last_updated;
+    array<Weather> daily_forecasts;
+  }
+
+  void ping();
+
+  GetForecastResponse getForecast(GetForecastRequest req);
+
+}

--- a/modules/haskell-integration-tests/src/main/scala/integrationtest/avro/MyWeatherService.scala
+++ b/modules/haskell-integration-tests/src/main/scala/integrationtest/avro/MyWeatherService.scala
@@ -14,10 +14,23 @@
  * limitations under the License.
  */
 
-package integrationtest
+package integrationtest.avro
 
-object DockerUtil {
+import cats.Applicative
+import cats.syntax.applicative._
+import weather._
+import higherkindness.mu.rpc.protocol.Empty
 
-  val ImageName = "cb372/mu-scala-haskell-integration-tests:latest"
+class MyWeatherService[F[_]: Applicative] extends WeatherService[F] {
+
+  def ping(req: Empty.type): F[Empty.type] =
+    Empty.pure[F]
+
+  def getForecast(req: weather.GetForecastRequest): F[GetForecastResponse] = {
+    val lastUpdated    = "2020-03-20T12:00:00Z"
+    val days           = if (req.days_required <= 0) 5 else req.days_required
+    val dailyForecasts = List.fill(days)(GetForecastResponse.Weather.SUNNY)
+    GetForecastResponse(lastUpdated, dailyForecasts).pure[F]
+  }
 
 }

--- a/modules/haskell-integration-tests/src/main/scala/integrationtest/avro/Protocol.scala
+++ b/modules/haskell-integration-tests/src/main/scala/integrationtest/avro/Protocol.scala
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2017-2020 47 Degrees, LLC. <http://www.47deg.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package integrationtest.avro
+
+import higherkindness.mu.rpc.protocol._
+
+object weather {
+
+  final case class GetForecastRequest(
+      city: String,
+      days_required: Int
+  )
+
+  final case class GetForecastResponse(
+      last_updated: String,
+      daily_forecasts: List[GetForecastResponse.Weather.Value]
+  )
+
+  object GetForecastResponse {
+
+    object Weather extends Enumeration {
+      type Weather = Value
+      val SUNNY, CLOUDY, RAINY = Value
+    }
+
+  }
+
+  @service(Avro, Gzip, namespace = Some("integrationtest"))
+  trait WeatherService[F[_]] {
+
+    def ping(req: Empty.type): F[Empty.type]
+
+    def getForecast(req: GetForecastRequest): F[GetForecastResponse]
+
+  }
+
+}

--- a/modules/haskell-integration-tests/src/main/scala/integrationtest/protobuf/MyWeatherService.scala
+++ b/modules/haskell-integration-tests/src/main/scala/integrationtest/protobuf/MyWeatherService.scala
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package integrationtest
+package integrationtest.protobuf
 
 import cats.Applicative
 import cats.syntax.applicative._

--- a/modules/haskell-integration-tests/src/main/scala/integrationtest/protobuf/Protocol.scala
+++ b/modules/haskell-integration-tests/src/main/scala/integrationtest/protobuf/Protocol.scala
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package integrationtest
+package integrationtest.protobuf
 
 import higherkindness.mu.rpc.protocol._
 import pbdirect._

--- a/modules/haskell-integration-tests/src/test/scala/integrationtest/Constants.scala
+++ b/modules/haskell-integration-tests/src/test/scala/integrationtest/Constants.scala
@@ -1,0 +1,26 @@
+/*
+ * Copyright 2017-2020 47 Degrees, LLC. <http://www.47deg.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package integrationtest
+
+object Constants {
+
+  val ImageName = "cb372/mu-scala-haskell-integration-tests:latest"
+
+  val ProtobufPort = 9123
+  val AvroPort     = 9124
+
+}

--- a/modules/haskell-integration-tests/src/test/scala/integrationtest/HaskellServerRunningInDocker.scala
+++ b/modules/haskell-integration-tests/src/test/scala/integrationtest/HaskellServerRunningInDocker.scala
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2017-2020 47 Degrees, LLC. <http://www.47deg.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package integrationtest
+
+import com.whisk.docker.DockerContainer
+import com.whisk.docker.scalatest.DockerTestKit
+import com.whisk.docker.impl.spotify.DockerKitSpotify
+import org.scalatest.Suite
+
+trait HaskellServerRunningInDocker extends DockerTestKit with DockerKitSpotify { self: Suite =>
+
+  def serverPort: Int
+  def serverExecutableName: String
+
+  override def dockerContainers: List[DockerContainer] = List(
+    DockerContainer(Constants.ImageName)
+      .withPorts(serverPort -> Some(serverPort))
+      .withCommand(s"/opt/mu-haskell-client-server/$serverExecutableName")
+  )
+
+  override def startAllOrFail(): Unit = {
+    println("Starting Mu-Haskell server in Docker container...")
+    super.startAllOrFail()
+    println("Started Docker container.")
+    Thread.sleep(2000) // give the Haskell server a chance to start up properly
+  }
+
+}

--- a/modules/haskell-integration-tests/src/test/scala/integrationtest/RunHaskellClientInDocker.scala
+++ b/modules/haskell-integration-tests/src/test/scala/integrationtest/RunHaskellClientInDocker.scala
@@ -1,0 +1,68 @@
+/*
+ * Copyright 2017-2020 47 Degrees, LLC. <http://www.47deg.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package integrationtest
+
+import com.spotify.docker.client._
+import com.spotify.docker.client.messages.ContainerConfig
+import com.spotify.docker.client.DockerClient._
+
+import org.scalatest.Suite
+
+trait RunHaskellClientInDocker { self: Suite =>
+
+  def clientExecutableName: String
+
+  val docker = DefaultDockerClient.fromEnv().build()
+
+  // An address for the RPC server that can be reached from inside a docker container
+  val hostExternalIpAddress = {
+    import sys.process._
+    if (sys.props("os.name").contains("Mac")) {
+      "ipconfig getifaddr en0".!!.trim
+    } else {
+      "hostname -I".!!.trim.split(" ").head
+    }
+  }
+
+  def containerConfig(clientArgs: List[String]) =
+    ContainerConfig
+      .builder()
+      .image(Constants.ImageName)
+      .cmd(
+        (s"/opt/mu-haskell-client-server/$clientExecutableName" :: hostExternalIpAddress :: clientArgs): _*
+      )
+      .build()
+
+  def runHaskellClient(clientArgs: List[String]) = {
+    val containerCreation = docker.createContainer(containerConfig(clientArgs))
+    val id                = containerCreation.id()
+    docker.startContainer(id)
+    val exit      = docker.waitContainer(id)
+    val logstream = docker.logs(id, LogsParam.stdout(), LogsParam.stderr())
+    try {
+      val output = logstream.readFully().trim()
+      assert(
+        exit.statusCode == 0,
+        s"Client exited with code ${exit.statusCode} and output: $output"
+      )
+      output
+    } finally {
+      logstream.close()
+    }
+  }
+
+}

--- a/modules/haskell-integration-tests/src/test/scala/integrationtest/avro/HaskellServerScalaClientSpec.scala
+++ b/modules/haskell-integration-tests/src/test/scala/integrationtest/avro/HaskellServerScalaClientSpec.scala
@@ -1,0 +1,82 @@
+/*
+ * Copyright 2017-2020 47 Degrees, LLC. <http://www.47deg.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package integrationtest.avro
+
+import integrationtest._
+import weather._
+import weather.GetForecastResponse.Weather.SUNNY
+import higherkindness.mu.rpc._
+import higherkindness.mu.rpc.protocol.Empty
+
+import io.grpc.CallOptions
+import cats.effect.{ContextShift, IO, Resource}
+
+import org.scalatest.flatspec.AnyFlatSpec
+
+import scala.concurrent.ExecutionContext
+
+class HaskellServerScalaClientSpec extends AnyFlatSpec with HaskellServerRunningInDocker {
+
+  def serverPort: Int              = Constants.AvroPort
+  def serverExecutableName: String = "avro-server"
+
+  implicit val CS: ContextShift[IO] = IO.contextShift(ExecutionContext.global)
+
+  val channelFor: ChannelFor = ChannelForAddress("localhost", serverPort)
+
+  val clientResource: Resource[IO, WeatherService[IO]] = WeatherService.client[IO](
+    channelFor,
+    options = CallOptions.DEFAULT.withCompression("gzip")
+  )
+
+  behavior of "Mu-Haskell server and Mu-Scala client communication using Avro"
+
+  it should "work for a trivial unary call" in {
+    pending
+    // until we upgrade to a version of Mu-Haskell that contains this fix:
+    // https://github.com/haskell-grpc-native/http2-grpc-haskell/pull/20
+    //
+    // However, I think this test may be failing for another reason.  I'm not
+    // sure what the correct behaviour is for a 'void' Avro method in gRPC.
+    // Mu-Scala treats that as "the server returns an `Empty` message", but I
+    // don't know what the Mu-Haskell server is returning. The test fails with
+    // "io.grpc.StatusRuntimeException: INTERNAL: No value received for unary
+    // call".
+
+    val response = clientResource
+      .use(client => client.ping(Empty))
+      .unsafeRunSync()
+    assert(response == Empty)
+  }
+
+  it should "work for a unary call" in {
+    pending
+    // until we upgrade to a version of Mu-Haskell that contains this fix:
+    // https://github.com/haskell-grpc-native/http2-grpc-haskell/pull/20
+
+    val request = GetForecastRequest("London", 3)
+    val expectedResponse = GetForecastResponse(
+      last_updated = "2020-03-20T12:00:00Z",
+      daily_forecasts = List(SUNNY, SUNNY, SUNNY)
+    )
+    val response = clientResource
+      .use(client => client.getForecast(request))
+      .unsafeRunSync()
+    assert(response == expectedResponse)
+  }
+
+}

--- a/modules/haskell-integration-tests/src/test/scala/integrationtest/avro/ScalaServerHaskellClientSpec.scala
+++ b/modules/haskell-integration-tests/src/test/scala/integrationtest/avro/ScalaServerHaskellClientSpec.scala
@@ -1,0 +1,77 @@
+/*
+ * Copyright 2017-2020 47 Degrees, LLC. <http://www.47deg.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package integrationtest.avro
+
+import integrationtest._
+import weather._
+import higherkindness.mu.rpc.server.{AddService, GrpcServer}
+
+import cats.effect.{ContextShift, IO}
+
+import org.scalatest.BeforeAndAfterAll
+import org.scalatest.flatspec.AnyFlatSpec
+
+import scala.concurrent.ExecutionContext
+
+class ScalaServerHaskellClientSpec
+    extends AnyFlatSpec
+    with RunHaskellClientInDocker
+    with BeforeAndAfterAll {
+
+  def clientExecutableName: String = "avro-client"
+
+  implicit val CS: ContextShift[IO] = IO.contextShift(ExecutionContext.global)
+
+  implicit val service: WeatherService[IO] = new MyWeatherService[IO]
+
+  private val startServer: IO[Unit] = for {
+    serviceDef <- WeatherService.bindService[IO]
+    serverDef  <- GrpcServer.default[IO](Constants.AvroPort, List(AddService(serviceDef)))
+    _          <- GrpcServer.server[IO](serverDef)
+  } yield ()
+
+  private var cancelToken: IO[Unit] = IO.unit
+
+  override def beforeAll(): Unit = {
+    cancelToken = startServer.unsafeRunCancelable {
+      case Left(e) =>
+        println(s"Server failed! $e")
+      case Right(_) =>
+        println("Server completed (this should never happen)")
+    }
+    Thread.sleep(500) // give the server a chance to start up
+  }
+
+  override def afterAll(): Unit =
+    // stop the server
+    cancelToken.unsafeRunSync()
+
+  behavior of "Mu-Scala server and Mu-Haskell client communication using Avro"
+
+  it should "work for a trivial unary call" in {
+    val clientOutput = runHaskellClient(List("ping"))
+    assert(clientOutput == "pong")
+  }
+
+  it should "work for a unary call" in {
+    val clientOutput = runHaskellClient(List("get-forecast", "London", "3"))
+    assert(
+      clientOutput == """2020-03-20T12:00:00Z ["SUNNY","SUNNY","SUNNY"]"""
+    )
+  }
+
+}


### PR DESCRIPTION
## What this does?

* Add Mu-Haskell integration tests that use Avro
* Refactored the integration tests to share Docker-related code between the Avro and Protobuf tests
* Tidy up the Haskell code slightly and apply a formatter

## Checklist

- [ ] Reviewed the diff to look for typos, println and format errors.
- [ ] Updated the docs accordingly.

