### PR TITLE
Wrap streaming responses in effect

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -51,6 +51,8 @@ lazy val channel = project
   .in(file("modules/channel"))
   .dependsOn(common % "compile->compile;test->test")
   .dependsOn(`internal-core` % "compile->compile;test->test")
+  .dependsOn(`internal-fs2` % "test->test")
+  .dependsOn(`internal-monix` % "test->test")
   .dependsOn(testing % "test->test")
   .settings(moduleName := "mu-rpc-channel")
   .settings(clientCoreSettings)

--- a/docs/src/main/docs/guides/grpc-streaming.md
+++ b/docs/src/main/docs/guides/grpc-streaming.md
@@ -78,7 +78,7 @@ object MonixService {
      * @param request Single client request.
      * @return Stream of server responses.
      */
-    def lotsOfReplies(request: HelloRequest): Observable[HelloResponse]
+    def lotsOfReplies(request: HelloRequest): F[Observable[HelloResponse]]
 
     /**
      * Client streaming RPC where the client writes a sequence of messages and sends them to the server,
@@ -104,7 +104,7 @@ object MonixService {
      * @param request Stream of client requests.
      * @return Stream of server responses.
      */
-    def bidiHello(request: Observable[HelloRequest]): Observable[HelloResponse]
+    def bidiHello(request: Observable[HelloRequest]): F[Observable[HelloResponse]]
 
   }
 
@@ -138,7 +138,7 @@ object servicefs2 {
      * @param request Single client request.
      * @return Stream of server responses.
      */
-    def lotsOfReplies(request: HelloRequest): Stream[F, HelloResponse]
+    def lotsOfReplies(request: HelloRequest): F[Stream[F, HelloResponse]]
 
     /**
      * Client streaming RPC
@@ -154,7 +154,7 @@ object servicefs2 {
      * @param request Stream of client requests.
      * @return Stream of server responses.
      */
-    def bidiHello(request: Stream[F, HelloRequest]): Stream[F, HelloResponse]
+    def bidiHello(request: Stream[F, HelloRequest]): F[Stream[F, HelloResponse]]
 
   }
 

--- a/modules/channel/src/test/scala/higherkindness/mu/rpc/MacroAnnotationCompilationTest.scala
+++ b/modules/channel/src/test/scala/higherkindness/mu/rpc/MacroAnnotationCompilationTest.scala
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2017-2020 47 Degrees, LLC. <http://www.47deg.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package higherkindness.mu.rpc
+
+import higherkindness.mu.rpc.protocol._
+import fs2.Stream
+import monix.reactive.Observable
+
+// This is not a normal "test" with assertions.
+// It's just a check that valid code compiles as expected
+// after the @service macro has been expanded.
+object MacroAnnotationCompilationTest {
+
+  final case class MyReq()
+  final case class MyResp(a: Int)
+
+  @service(Protobuf)
+  trait MyFS2Service[F[_]] {
+
+    def trivial(req: Empty.type): F[Empty.type]
+
+    def unary(req: MyReq): F[MyResp]
+
+    def clientStreaming(req: Stream[F, MyReq]): F[MyResp]
+
+    def clientStreamingFullyQualifiedStream(req: _root_.fs2.Stream[F, MyReq]): F[MyResp]
+
+    def serverStreaming(req: MyReq): F[Stream[F, MyResp]]
+
+    def bidirectionalStreaming(req: Stream[F, MyReq]): F[Stream[F, MyResp]]
+
+  }
+
+  @service(Protobuf)
+  trait MyMonixService[F[_]] {
+
+    def trivial(req: Empty.type): F[Empty.type]
+
+    def unary(req: MyReq): F[MyResp]
+
+    def clientStreaming(req: Observable[MyReq]): F[MyResp]
+
+    def clientStreamingFullyQualifiedStream(req: Observable[MyReq]): F[MyResp]
+
+    def serverStreaming(req: MyReq): F[Observable[MyResp]]
+
+    def bidirectionalStreaming(req: Observable[MyReq]): F[Observable[MyResp]]
+
+  }
+
+}

--- a/modules/haskell-integration-tests/src/main/scala/integrationtest/protobuf/MyWeatherService.scala
+++ b/modules/haskell-integration-tests/src/main/scala/integrationtest/protobuf/MyWeatherService.scala
@@ -53,9 +53,10 @@ class MyWeatherService[F[_]: Applicative](implicit compiler: Compiler[F, F])
     rainStartedCount.map(RainSummaryResponse)
   }
 
-  def subscribeToRainEvents(req: SubscribeToRainEventsRequest): Stream[F, RainEvent] =
+  def subscribeToRainEvents(req: SubscribeToRainEventsRequest): F[Stream[F, RainEvent]] =
     Stream(STARTED, STOPPED, STARTED, STOPPED, STARTED)
       .map(RainEvent(req.city, _))
       .covary[F]
+      .pure[F]
 
 }

--- a/modules/haskell-integration-tests/src/main/scala/integrationtest/protobuf/Protocol.scala
+++ b/modules/haskell-integration-tests/src/main/scala/integrationtest/protobuf/Protocol.scala
@@ -84,7 +84,7 @@ object weather {
 
     def publishRainEvents(req: Stream[F, RainEvent]): F[RainSummaryResponse]
 
-    def subscribeToRainEvents(req: SubscribeToRainEventsRequest): Stream[F, RainEvent]
+    def subscribeToRainEvents(req: SubscribeToRainEventsRequest): F[Stream[F, RainEvent]]
 
   }
 

--- a/modules/haskell-integration-tests/src/test/scala/integrationtest/protobuf/HaskellServerScalaClientSpec.scala
+++ b/modules/haskell-integration-tests/src/test/scala/integrationtest/protobuf/HaskellServerScalaClientSpec.scala
@@ -97,7 +97,7 @@ class HaskellServerScalaClientSpec extends AnyFlatSpec with HaskellServerRunning
 
     val request = SubscribeToRainEventsRequest("London")
     val stream: Stream[IO, RainEvent] = clientResource
-      .use(client => IO(client.subscribeToRainEvents(request)))
+      .use(client => client.subscribeToRainEvents(request))
       .unsafeRunSync()
     val events = stream.compile.toList.unsafeRunSync()
     val expectedEvents =

--- a/modules/http/src/test/scala/higherkindness/mu/rpc/http/GreeterDerivedRestTests.scala
+++ b/modules/http/src/test/scala/higherkindness/mu/rpc/http/GreeterDerivedRestTests.scala
@@ -116,9 +116,9 @@ class GreeterDerivedRestTests extends RpcBaseTestSuite with BeforeAndAfter {
     "serve a POST request with fs2 streaming response" in {
       val request = HelloRequest("hey")
       val responses =
-        BlazeClientBuilder[IO](ec).stream.flatMap(client =>
-          Stream.eval(fs2Client.sayHelloAll(request)(client)).flatten
-        )
+        BlazeClientBuilder[IO](ec).stream
+          .evalMap(client => fs2Client.sayHelloAll(request)(client))
+          .flatten
       responses.compile.toList
         .unsafeRunSync() shouldBe List(HelloResponse("hey"), HelloResponse("hey"))
     }

--- a/modules/http/src/test/scala/higherkindness/mu/rpc/http/GreeterHandlers.scala
+++ b/modules/http/src/test/scala/higherkindness/mu/rpc/http/GreeterHandlers.scala
@@ -17,12 +17,13 @@
 package higherkindness.mu.rpc.http
 
 import cats.{Applicative, MonadError}
+import cats.syntax.applicative._
+import cats.syntax.functor._
 import cats.effect._
 
 class UnaryGreeterHandler[F[_]: Applicative](implicit F: MonadError[F, Throwable])
     extends UnaryGreeter[F] {
 
-  import cats.syntax.applicative._
   import higherkindness.mu.rpc.protocol.Empty
   import io.grpc.Status._
 
@@ -41,7 +42,6 @@ class UnaryGreeterHandler[F[_]: Applicative](implicit F: MonadError[F, Throwable
 class Fs2GreeterHandler[F[_]: Sync] extends Fs2Greeter[F] {
 
   import fs2.Stream
-  import cats.syntax.functor._
   import higherkindness.mu.rpc.protocol.Empty
 
   def sayHellos(requests: Stream[F, HelloRequest]): F[HelloResponse] =
@@ -55,19 +55,17 @@ class Fs2GreeterHandler[F[_]: Sync] extends Fs2Greeter[F] {
   def rudelyIgnoreStreamOfHellos(requests: Stream[F, HelloRequest]): F[Empty.type] =
     requests.compile.drain.as(Empty)
 
-  def sayHelloAll(request: HelloRequest): F[Stream[F, HelloResponse]] =
-    Applicative[F].pure(
+  def sayHelloAll(request: HelloRequest): F[Stream[F, HelloResponse]] = {
+    val stream = {
       if (request.hello.isEmpty) Stream.raiseError(new IllegalArgumentException("empty greeting"))
       else Stream(HelloResponse(request.hello), HelloResponse(request.hello))
-    )
+    }
+    stream.pure[F]
+  }
 
   def sayHelloAllEmptyRequest(request: Empty.type): F[Stream[F, HelloResponse]] =
-    Applicative[F].pure(
-      Stream(HelloResponse("hey"), HelloResponse("hi again"))
-    )
+    Stream(HelloResponse("hey"), HelloResponse("hi again")).covary[F].pure[F]
 
   def sayHellosAll(requests: Stream[F, HelloRequest]): F[Stream[F, HelloResponse]] =
-    Applicative[F].pure(
-      requests.map(request => HelloResponse(request.hello))
-    )
+    requests.map(request => HelloResponse(request.hello)).pure[F]
 }

--- a/modules/http/src/test/scala/higherkindness/mu/rpc/http/GreeterRestServices.scala
+++ b/modules/http/src/test/scala/higherkindness/mu/rpc/http/GreeterRestServices.scala
@@ -63,12 +63,17 @@ class Fs2GreeterRestService[F[_]: Sync](
 
     case msg @ POST -> Root / "sayHelloAll" =>
       for {
-        request   <- msg.as[HelloRequest]
-        responses <- Ok(handler.sayHelloAll(request).asJsonEither)
+        request    <- msg.as[HelloRequest]
+        respStream <- handler.sayHelloAll(request)
+        responses  <- Ok(respStream.asJsonEither)
       } yield responses
 
     case msg @ POST -> Root / "sayHellosAll" =>
       val requests = msg.asStream[HelloRequest]
-      Ok(handler.sayHellosAll(requests).asJsonEither)
+      for {
+        respStream <- handler.sayHellosAll(requests)
+        responses  <- Ok(respStream.asJsonEither)
+      } yield responses
+
   }
 }

--- a/modules/http/src/test/scala/higherkindness/mu/rpc/http/GreeterServices.scala
+++ b/modules/http/src/test/scala/higherkindness/mu/rpc/http/GreeterServices.scala
@@ -38,7 +38,12 @@ import fs2.Stream
 
   @http def sayHellos(requests: Stream[F, HelloRequest]): F[HelloResponse]
 
-  @http def sayHelloAll(request: HelloRequest): Stream[F, HelloResponse]
+  @http def rudelyIgnoreStreamOfHellos(requests: Stream[F, HelloRequest]): F[Empty.type]
 
-  @http def sayHellosAll(requests: Stream[F, HelloRequest]): Stream[F, HelloResponse]
+  @http def sayHelloAll(request: HelloRequest): F[Stream[F, HelloResponse]]
+
+  @http def sayHelloAllEmptyRequest(request: Empty.type): F[Stream[F, HelloResponse]]
+
+  @http def sayHellosAll(requests: Stream[F, HelloRequest]): F[Stream[F, HelloResponse]]
+
 }

--- a/modules/internal/fs2/src/main/scala/higherkindness/mu/client/fs2Calls.scala
+++ b/modules/internal/fs2/src/main/scala/higherkindness/mu/client/fs2Calls.scala
@@ -17,6 +17,7 @@
 package higherkindness.mu.rpc.internal.client
 
 import cats.effect.ConcurrentEffect
+import cats.syntax.applicative._
 import cats.syntax.flatMap._
 import fs2.Stream
 import io.grpc.{CallOptions, Channel, Metadata, MethodDescriptor}
@@ -38,10 +39,11 @@ object fs2Calls {
       descriptor: MethodDescriptor[Req, Res],
       channel: Channel,
       options: CallOptions
-  ): Stream[F, Res] =
+  ): F[Stream[F, Res]] =
     Stream
       .eval(Fs2ClientCall[F](channel, descriptor, options))
       .flatMap(_.unaryToStreamingCall(request, new Metadata()))
+      .pure[F]
 
   def clientStreaming[F[_]: ConcurrentEffect, Req, Res](
       input: Stream[F, Req],
@@ -57,8 +59,9 @@ object fs2Calls {
       descriptor: MethodDescriptor[Req, Res],
       channel: Channel,
       options: CallOptions
-  ): Stream[F, Res] =
+  ): F[Stream[F, Res]] =
     Stream
       .eval(Fs2ClientCall[F](channel, descriptor, options))
       .flatMap(_.streamingToStreamingCall(input, new Metadata()))
+      .pure[F]
 }

--- a/modules/internal/fs2/src/main/scala/higherkindness/mu/server/fs2Calls.scala
+++ b/modules/internal/fs2/src/main/scala/higherkindness/mu/server/fs2Calls.scala
@@ -53,20 +53,20 @@ object fs2Calls {
     )
 
   def serverStreamingMethod[F[_]: ConcurrentEffect, Req, Res](
-      f: Req => Stream[F, Res],
+      f: Req => F[Stream[F, Res]],
       compressionType: CompressionType
   ): ServerCallHandler[Req, Res] =
     Fs2ServerCallHandler[F].unaryToStreamingCall[Req, Res](
-      (req, _) => f(req),
+      (req, _) => Stream.eval(f(req)).flatten,
       serverCallOptions(compressionType)
     )
 
   def bidiStreamingMethod[F[_]: ConcurrentEffect, Req, Res](
-      f: Stream[F, Req] => Stream[F, Res],
+      f: Stream[F, Req] => F[Stream[F, Res]],
       compressionType: CompressionType
   ): ServerCallHandler[Req, Res] =
     Fs2ServerCallHandler[F].streamingToStreamingCall[Req, Res](
-      (stream, _) => f(stream),
+      (stream, _) => Stream.eval(f(stream)).flatten,
       serverCallOptions(compressionType)
     )
 

--- a/modules/internal/src/main/scala/higherkindness/mu/rpc/internal/serviceImpl.scala
+++ b/modules/internal/src/main/scala/higherkindness/mu/rpc/internal/serviceImpl.scala
@@ -28,15 +28,28 @@ object serviceImpl {
     import c.universe._
     import Flag._
 
-    abstract class TypeTypology(tpe: Tree, inner: Option[Tree]) extends Product with Serializable {
-      def getTpe: Tree           = tpe
-      def getInner: Option[Tree] = inner
-      def safeInner: Tree        = inner.getOrElse(tpe)
-      def safeType: Tree = tpe match {
-        case tq"${s @ _}[..$tpts]" if isStreaming => tpts.last
-        case other                                => other
-      }
-      def flatName: String = safeInner.toString
+    /**
+     * @originalType The original type written by the user.
+     *               For a request type, this will be e.g. `MyRequest` or `Stream[F, MyRequest]`
+     *               or `Observable[MyRequest]`.
+     *               For a response type, it will be inside an effect type,
+     *               e.g. `F[MyResponse]` or `F[Stream[F, MyResponse]]` or `F[Observable[MyResponse]]`
+     *
+     * @unwrappedType The type, with any surrounding effect type stripped.
+     *                e.g. `MyRequest` or `Stream[F, MyRequest]` or `Observable[MyRequest]`
+     *                For a request type, `unwrappedType` == `originalType`.
+     *
+     * @messageType The type of the message in a request/response.
+     *              For non-streaming request/responses, `messageType` == `unwrappedType`.
+     *              For streaming request/responses, `messageType` is the type of the stream elements.
+     *              e.g. if `originalType` is `F[Stream[F, MyResponse]]` then `messageType` is `MyResponse`.
+     */
+    abstract class TypeTypology(
+        val originalType: Tree,
+        val unwrappedType: Tree,
+        val messageType: Tree
+    ) extends Product
+        with Serializable {
 
       def isEmpty: Boolean = this match {
         case _: EmptyTpe => true
@@ -50,19 +63,55 @@ object serviceImpl {
       }
     }
     object TypeTypology {
-      def apply(t: Tree): TypeTypology = t match {
-        case tq"Observable[..$tpts]"                        => MonixObservableTpe(t, tpts.headOption)
-        case tq"_root_.monix.reactive.Observable[..$tpts]"  => MonixObservableTpe(t, tpts.headOption)
-        case tq"Stream[${carrier @ _}, ..$tpts]"            => Fs2StreamTpe(t, tpts.headOption)
-        case tq"_root_.fs2.Stream[${carrier @ _}, ..$tpts]" => Fs2StreamTpe(t, tpts.headOption)
-        case tq"Empty.type"                                 => EmptyTpe(t)
-        case tq"${carrier @ _}[..$tpts]"                    => UnaryTpe(t, tpts.headOption)
+
+      private def identOrSelect(tree: Tree, name: String): Boolean = tree match {
+        case Ident(TypeName(`name`)) | Select(_, TypeName(`name`)) => true
+        case _                                                     => false
       }
+
+      def apply(t: Tree, responseType: Boolean, F: TypeName): TypeTypology = {
+        val unwrappedType: Tree = {
+          if (responseType) {
+            // Check that the type is wrapped in F as it should be, and unwrap it
+            t match {
+              case tq"$f[$tparam]" if f.toString == F.decodedName.toString => tparam
+              case _ =>
+                c.abort(
+                  t.pos,
+                  "Invalid RPC response type. All response types should have the shape F[...], where F[_] is the service's type parameter."
+                )
+            }
+          } else {
+            // Request type is not wrapped in F[...], so return it as-is
+            t
+          }
+        }
+
+        unwrappedType match {
+          case tq"$tpe[$elemType]" if identOrSelect(tpe, "Observable") =>
+            MonixObservableTpe(t, unwrappedType, elemType)
+          case tq"$tpe[$effectType, $elemType]"
+              if identOrSelect(tpe, "Stream") && effectType.toString == F.decodedName.toString =>
+            Fs2StreamTpe(t, unwrappedType, elemType)
+          case tq"Empty.type" => EmptyTpe(t, unwrappedType, unwrappedType)
+          case other          => UnaryTpe(t, unwrappedType, unwrappedType)
+        }
+
+      }
+
     }
-    case class EmptyTpe(tpe: Tree)                                extends TypeTypology(tpe, None)
-    case class UnaryTpe(tpe: Tree, inner: Option[Tree])           extends TypeTypology(tpe, inner)
-    case class Fs2StreamTpe(tpe: Tree, inner: Option[Tree])       extends TypeTypology(tpe, inner)
-    case class MonixObservableTpe(tpe: Tree, inner: Option[Tree]) extends TypeTypology(tpe, inner)
+
+    case class EmptyTpe(orig: Tree, unwrapped: Tree, message: Tree)
+        extends TypeTypology(orig, unwrapped, message)
+
+    case class UnaryTpe(orig: Tree, unwrapped: Tree, message: Tree)
+        extends TypeTypology(orig, unwrapped, message)
+
+    case class Fs2StreamTpe(orig: Tree, unwrapped: Tree, streamElem: Tree)
+        extends TypeTypology(orig, unwrapped, streamElem)
+
+    case class MonixObservableTpe(orig: Tree, unwrapped: Tree, streamElem: Tree)
+        extends TypeTypology(orig, unwrapped, streamElem)
 
     case class Operation(name: TermName, request: TypeTypology, response: TypeTypology) {
 
@@ -76,9 +125,9 @@ object serviceImpl {
       }
 
       val validStreamingComb: Boolean = (request, response) match {
-        case (Fs2StreamTpe(_, _), MonixObservableTpe(_, _)) => false
-        case (MonixObservableTpe(_, _), Fs2StreamTpe(_, _)) => false
-        case _                                              => true
+        case (_: Fs2StreamTpe, _: MonixObservableTpe) => false
+        case (_: MonixObservableTpe, _: Fs2StreamTpe) => false
+        case _                                        => true
       }
 
       require(
@@ -168,6 +217,11 @@ object serviceImpl {
       val F_ : TypeDef = serviceDef.tparams.head
       val F: TypeName  = F_.name
 
+      require(
+        F_.tparams.length == 1,
+        s"@service-annotated class $serviceName's type parameter must be higher-kinded"
+      )
+
       private val defs: List[Tree] = serviceDef.impl.body
 
       private val (rpcDefs, nonRpcDefs) = defs.collect {
@@ -210,11 +264,15 @@ object serviceImpl {
         params <- d.vparamss
         _ = require(params.length == 1, s"RPC call ${d.name} has more than one request parameter")
         p <- params.headOption.toList
-      } yield RpcRequest(
-        Operation(d.name, TypeTypology(p.tpt), TypeTypology(d.tpt)),
-        compressionType,
-        methodNameStyle
-      )
+      } yield {
+        val requestType  = TypeTypology(p.tpt, false, F)
+        val responseType = TypeTypology(d.tpt, true, F)
+        RpcRequest(
+          Operation(d.name, requestType, responseType),
+          compressionType,
+          methodNameStyle
+        )
+      }
 
       val imports: List[Tree] = defs.collect {
         case imp: Import => imp
@@ -420,15 +478,16 @@ object serviceImpl {
 
         private val methodDescriptorValName = TermName("_methodDescriptor")
 
-        private val reqType = request.safeType
-
-        private val respType = response.safeInner
+        private val reqType         = request.originalType
+        private val reqElemType     = request.messageType
+        private val wrappedRespType = response.originalType
+        private val respElemType    = response.messageType
 
         val methodDescriptorDef: DefDef = q"""
           def $methodDescriptorDefName(implicit
-            ReqM: _root_.io.grpc.MethodDescriptor.Marshaller[$reqType],
-            RespM: _root_.io.grpc.MethodDescriptor.Marshaller[$respType]
-          ): _root_.io.grpc.MethodDescriptor[$reqType, $respType] = {
+            ReqM: _root_.io.grpc.MethodDescriptor.Marshaller[$reqElemType],
+            RespM: _root_.io.grpc.MethodDescriptor.Marshaller[$respElemType]
+          ): _root_.io.grpc.MethodDescriptor[$reqElemType, $respElemType] = {
             _root_.io.grpc.MethodDescriptor
               .newBuilder(
                 ReqM,
@@ -442,7 +501,7 @@ object serviceImpl {
         """.supressWarts("Null", "ExplicitImplicitTypes")
 
         val methodDescriptorVal: ValDef = q"""
-          val $methodDescriptorValName: _root_.io.grpc.MethodDescriptor[$reqType, $respType] =
+          val $methodDescriptorValName: _root_.io.grpc.MethodDescriptor[$reqElemType, $respElemType] =
             $methodDescriptorDefName
         """
 
@@ -454,51 +513,51 @@ object serviceImpl {
         """
 
         private def clientCallMethodFor(clientMethodName: String) =
-          q"$clientCallsImpl.${TermName(clientMethodName)}(input, $methodDescriptorName.$methodDescriptorValName, channel, options)"
+          q"$clientCallsImpl.${TermName(clientMethodName)}[$F, $reqElemType, $respElemType](input, $methodDescriptorName.$methodDescriptorValName, channel, options)"
 
         val clientDef: Tree = streamingType match {
           case Some(RequestStreaming) =>
             q"""
-            def $name(input: ${request.getTpe}): ${response.getTpe} = ${clientCallMethodFor(
+            def $name(input: $reqType): $wrappedRespType = ${clientCallMethodFor(
               "clientStreaming"
             )}"""
           case Some(ResponseStreaming) =>
             q"""
-            def $name(input: ${request.getTpe}): ${response.getTpe} = ${clientCallMethodFor(
+            def $name(input: $reqType): $wrappedRespType = ${clientCallMethodFor(
               "serverStreaming"
             )}"""
           case Some(BidirectionalStreaming) =>
             q"""
-            def $name(input: ${request.getTpe}): ${response.getTpe} = ${clientCallMethodFor(
+            def $name(input: $reqType): $wrappedRespType = ${clientCallMethodFor(
               "bidiStreaming"
             )}"""
           case None =>
             q"""
-            def $name(input: ${request.getTpe}): ${response.getTpe} = ${clientCallMethodFor("unary")}"""
+            def $name(input: $reqType): $wrappedRespType = ${clientCallMethodFor("unary")}"""
         }
 
         private def monixServerCallMethodFor(serverMethodName: String) =
-          q"_root_.higherkindness.mu.rpc.internal.server.monixCalls.${TermName(serverMethodName)}(algebra.$name, $compressionTypeTree)"
+          q"_root_.higherkindness.mu.rpc.internal.server.monixCalls.${TermName(serverMethodName)}[$F, $reqElemType, $respElemType](algebra.$name, $compressionTypeTree)"
 
         val descriptorAndHandler: Tree = {
           val handler = (streamingType, prevalentStreamingTarget) match {
-            case (Some(RequestStreaming), Fs2StreamTpe(_, _)) =>
-              q"_root_.higherkindness.mu.rpc.internal.server.fs2Calls.clientStreamingMethod(algebra.$name, $compressionTypeTree)"
-            case (Some(RequestStreaming), MonixObservableTpe(_, _)) =>
+            case (Some(RequestStreaming), _: Fs2StreamTpe) =>
+              q"_root_.higherkindness.mu.rpc.internal.server.fs2Calls.clientStreamingMethod[$F, $reqElemType, $respElemType](algebra.$name, $compressionTypeTree)"
+            case (Some(RequestStreaming), _: MonixObservableTpe) =>
               q"_root_.io.grpc.stub.ServerCalls.asyncClientStreamingCall(${monixServerCallMethodFor("clientStreamingMethod")})"
 
-            case (Some(ResponseStreaming), Fs2StreamTpe(_, _)) =>
-              q"_root_.higherkindness.mu.rpc.internal.server.fs2Calls.serverStreamingMethod(algebra.$name, $compressionTypeTree)"
-            case (Some(ResponseStreaming), MonixObservableTpe(_, _)) =>
+            case (Some(ResponseStreaming), _: Fs2StreamTpe) =>
+              q"_root_.higherkindness.mu.rpc.internal.server.fs2Calls.serverStreamingMethod[$F, $reqElemType, $respElemType](algebra.$name, $compressionTypeTree)"
+            case (Some(ResponseStreaming), _: MonixObservableTpe) =>
               q"_root_.io.grpc.stub.ServerCalls.asyncServerStreamingCall(${monixServerCallMethodFor("serverStreamingMethod")})"
 
-            case (Some(BidirectionalStreaming), Fs2StreamTpe(_, _)) =>
-              q"_root_.higherkindness.mu.rpc.internal.server.fs2Calls.bidiStreamingMethod(algebra.$name, $compressionTypeTree)"
-            case (Some(BidirectionalStreaming), MonixObservableTpe(_, _)) =>
+            case (Some(BidirectionalStreaming), _: Fs2StreamTpe) =>
+              q"_root_.higherkindness.mu.rpc.internal.server.fs2Calls.bidiStreamingMethod[$F, $reqElemType, $respElemType](algebra.$name, $compressionTypeTree)"
+            case (Some(BidirectionalStreaming), _: MonixObservableTpe) =>
               q"_root_.io.grpc.stub.ServerCalls.asyncBidiStreamingCall(${monixServerCallMethodFor("bidiStreamingMethod")})"
 
             case (None, _) =>
-              q"_root_.io.grpc.stub.ServerCalls.asyncUnaryCall(_root_.higherkindness.mu.rpc.internal.server.unaryCalls.unaryMethod(algebra.$name, $compressionTypeTree))"
+              q"_root_.io.grpc.stub.ServerCalls.asyncUnaryCall(_root_.higherkindness.mu.rpc.internal.server.unaryCalls.unaryMethod[$F, $reqElemType, $respElemType](algebra.$name, $compressionTypeTree))"
             case _ =>
               sys.error(
                 s"Unable to define a handler for the streaming type $streamingType and $prevalentStreamingTarget for the method $name in the service $serviceName"
@@ -519,13 +578,6 @@ object serviceImpl {
           case _           => TermName("POST")
         }
 
-        val executionClient: Tree = response match {
-          case Fs2StreamTpe(_, _) =>
-            q"client.stream(request).flatMap(_.asStream[${response.safeInner}])"
-          case _ =>
-            q"""client.expectOr[${response.safeInner}](request)(handleResponseError)(jsonOf[F, ${response.safeInner}])"""
-        }
-
         val requestTypology: Tree = request match {
           case _: UnaryTpe =>
             q"val request = _root_.org.http4s.Request[F](_root_.org.http4s.Method.$method, uri / ${uri
@@ -538,51 +590,85 @@ object serviceImpl {
               .replace("\"", "")})"
         }
 
-        val responseEncoder =
-          q"""implicit val responseEntityDecoder: _root_.org.http4s.EntityDecoder[F, ${response.safeInner}] = jsonOf[F, ${response.safeInner}]"""
+        val executionClient: Tree = response match {
+          case _: Fs2StreamTpe =>
+            q"_root_.cats.Applicative[F].pure(client.stream(request).flatMap(_.asStream[${response.messageType}]))"
+          case _ =>
+            q"""client.expectOr[${response.messageType}](request)(handleResponseError)(_root_.org.http4s.circe.jsonOf[F, ${response.messageType}])"""
+        }
 
         def toRequestTree: Tree = request match {
           case _: EmptyTpe =>
             q"""def $name(client: _root_.org.http4s.client.Client[F])(
-               implicit responseDecoder: _root_.io.circe.Decoder[${response.safeInner}]): ${response.getTpe} = {
-		                  $responseEncoder
-		                  $requestTypology
-		                  $executionClient
-		                 }"""
+                 implicit responseDecoder: _root_.io.circe.Decoder[${response.messageType}]): ${response.originalType} = {
+                   $requestTypology
+                   $executionClient
+                 }"""
           case _ =>
-            q"""def $name(req: ${request.getTpe})(client: _root_.org.http4s.client.Client[F])(
-               implicit requestEncoder: _root_.io.circe.Encoder[${request.safeInner}],
-               responseDecoder: _root_.io.circe.Decoder[${response.safeInner}]
-            ): ${response.getTpe} = {
-		                  $responseEncoder
-		                  $requestTypology
-		                  $executionClient
-		                 }"""
+            q"""def $name(req: ${request.originalType})(client: _root_.org.http4s.client.Client[F])(
+                 implicit requestEncoder: _root_.io.circe.Encoder[${request.messageType}],
+                 responseDecoder: _root_.io.circe.Decoder[${response.messageType}]
+              ): ${response.originalType} = {
+                $requestTypology
+                $executionClient
+              }"""
         }
 
         val routeTypology: Tree = (request, response) match {
-          case (_: Fs2StreamTpe, _: UnaryTpe) =>
-            q"""val requests = msg.asStream[${operation.request.safeInner}]
-              _root_.org.http4s.Status.Ok.apply(handler.${operation.name}(requests).map(_.asJson))"""
-
-          case (_: UnaryTpe, _: Fs2StreamTpe) =>
-            q"""for {
-              request   <- msg.as[${operation.request.safeInner}]
-              responses <- _root_.org.http4s.Status.Ok.apply(handler.${operation.name}(request).asJsonEither)
-            } yield responses"""
-
+          // Stream -> Stream
           case (_: Fs2StreamTpe, _: Fs2StreamTpe) =>
-            q"""val requests = msg.asStream[${operation.request.safeInner}]
-             _root_.org.http4s.Status.Ok.apply(handler.${operation.name}(requests).asJsonEither)"""
+            q"""val requests = msg.asStream[${operation.request.messageType}]
+                for {
+                  respStream <- handler.${operation.name}(requests)
+                  responses  <- _root_.org.http4s.Status.Ok.apply(respStream.asJsonEither)
+                } yield responses"""
 
-          case (_: EmptyTpe, _) =>
+          // Stream -> Empty
+          case (_: Fs2StreamTpe, _: EmptyTpe) =>
+            q"""val requests = msg.asStream[${operation.request.messageType}]
+                _root_.org.http4s.Status.Ok.apply(handler.${operation.name}(requests).as(()))"""
+
+          // Stream -> Unary
+          case (_: Fs2StreamTpe, _: UnaryTpe) =>
+            q"""val requests = msg.asStream[${operation.request.messageType}]
+                _root_.org.http4s.Status.Ok.apply(handler.${operation.name}(requests).map(_.asJson))"""
+
+          // Empty -> Stream
+          case (_: EmptyTpe, _: Fs2StreamTpe) =>
+            q"""for {
+                  respStream <- handler.${operation.name}(_root_.higherkindness.mu.rpc.protocol.Empty)
+                  responses  <- _root_.org.http4s.Status.Ok.apply(respStream.asJsonEither)
+                } yield responses"""
+
+          // Empty -> Empty
+          case (_: EmptyTpe, _: EmptyTpe) =>
+            q"""_root_.org.http4s.Status.Ok.apply(handler.${operation.name}(_root_.higherkindness.mu.rpc.protocol.Empty).as(()))"""
+
+          // Empty -> Unary
+          case (_: EmptyTpe, _: UnaryTpe) =>
             q"""_root_.org.http4s.Status.Ok.apply(handler.${operation.name}(_root_.higherkindness.mu.rpc.protocol.Empty).map(_.asJson))"""
 
+          // Unary -> Stream
+          case (_: UnaryTpe, _: Fs2StreamTpe) =>
+            q"""for {
+                request    <- msg.as[${operation.request.messageType}]
+                respStream <- handler.${operation.name}(request)
+                responses  <- _root_.org.http4s.Status.Ok.apply(respStream.asJsonEither)
+              } yield responses"""
+
+          // Unary -> Empty
+          case (_: UnaryTpe, _: EmptyTpe) =>
+            q"""for {
+                request  <- msg.as[${operation.request.messageType}]
+                response <- _root_.org.http4s.Status.Ok.apply(handler.${operation.name}(request).as(())).adaptErrors
+              } yield response"""
+
+          // Unary -> Unary
           case _ =>
             q"""for {
-              request  <- msg.as[${operation.request.safeInner}]
-              response <- _root_.org.http4s.Status.Ok.apply(handler.${operation.name}(request).map(_.asJson)).adaptErrors
-            } yield response"""
+                request  <- msg.as[${operation.request.messageType}]
+                response <- _root_.org.http4s.Status.Ok.apply(handler.${operation.name}(request).map(_.asJson)).adaptErrors
+              } yield response"""
         }
 
         val getPattern =
@@ -604,7 +690,9 @@ object serviceImpl {
         params <- d.vparamss
         _ = require(params.length == 1, s"RPC call ${d.name} has more than one request parameter")
         p <- params.headOption.toList
-        op = Operation(d.name, TypeTypology(p.tpt), TypeTypology(d.tpt))
+        reqType  = TypeTypology(p.tpt, false, F)
+        respType = TypeTypology(d.tpt, true, F)
+        op       = Operation(d.name, reqType, respType)
         _ = if (op.isMonixObservable)
           sys.error(
             "Monix.Observable is not compatible with streaming services. Please consider using Fs2.Stream instead."
@@ -617,15 +705,15 @@ object serviceImpl {
 
       val HttpClient      = TypeName("HttpClient")
       val httpClientClass = q"""
-        class $HttpClient[$F_](uri: _root_.org.http4s.Uri)(implicit ..$streamConstraints) {
-          ..$httpRequests
-      }"""
+          class $HttpClient[$F_](uri: _root_.org.http4s.Uri)(implicit ..$streamConstraints) {
+            ..$httpRequests
+        }"""
 
       val httpClient = q"""
-        def httpClient[$F_](uri: _root_.org.http4s.Uri)
-          (implicit ..$streamConstraints): $HttpClient[$F] = {
-          new $HttpClient[$F](uri / ${serviceDef.name.toString})
-      }"""
+          def httpClient[$F_](uri: _root_.org.http4s.Uri)
+            (implicit ..$streamConstraints): $HttpClient[$F] = {
+            new $HttpClient[$F](uri / ${serviceDef.name.toString})
+        }"""
 
       val httpImports: List[Tree] = List(
         q"import _root_.higherkindness.mu.http.implicits._",
@@ -640,10 +728,16 @@ object serviceImpl {
       val routesPF: Tree = q"{ case ..$httpRoutesCases }"
 
       val requestTypes: Set[String] =
-        operations.filterNot(_.operation.request.isEmpty).map(_.operation.request.flatName).toSet
+        operations
+          .filterNot(_.operation.request.isEmpty)
+          .map(_.operation.request.messageType.toString)
+          .toSet
 
       val responseTypes: Set[String] =
-        operations.filterNot(_.operation.response.isEmpty).map(_.operation.response.flatName).toSet
+        operations
+          .filterNot(_.operation.response.isEmpty)
+          .map(_.operation.response.messageType.toString)
+          .toSet
 
       val requestDecoders =
         requestTypes.map(n =>
@@ -664,20 +758,21 @@ object serviceImpl {
         streamConstraints
 
       val httpRestServiceClass: Tree = q"""
-        class $HttpRestService[$F_](implicit ..$arguments) extends _root_.org.http4s.dsl.Http4sDsl[F] {
-         ..$requestDecoders
-         def service = _root_.org.http4s.HttpRoutes.of[F]{$routesPF}
-      }"""
+          class $HttpRestService[$F_](implicit ..$arguments) extends _root_.org.http4s.dsl.Http4sDsl[F] {
+           ..$requestDecoders
+           def service = _root_.org.http4s.HttpRoutes.of[F]{$routesPF}
+        }"""
 
       val httpService = q"""
-        def route[$F_](implicit ..$arguments): _root_.higherkindness.mu.http.protocol.RouteMap[F] = {
-          _root_.higherkindness.mu.http.protocol.RouteMap[F](${serviceDef.name.toString}, new $HttpRestService[$F].service)
-      }"""
+          def route[$F_](implicit ..$arguments): _root_.higherkindness.mu.http.protocol.RouteMap[F] = {
+            _root_.higherkindness.mu.http.protocol.RouteMap[F](${serviceDef.name.toString}, new $HttpRestService[$F].service)
+        }"""
 
       val http =
         if (httpRequests.isEmpty) Nil
         else
           httpImports ++ List(httpClientClass, httpClient, httpRestServiceClass, httpService)
+
     }
 
     val classAndMaybeCompanion = annottees.map(_.tree)

--- a/modules/server/src/test/scala/higherkindness/mu/rpc/fs2/RPCTests.scala
+++ b/modules/server/src/test/scala/higherkindness/mu/rpc/fs2/RPCTests.scala
@@ -74,7 +74,7 @@ class RPCTests extends RpcBaseTestSuite with BeforeAndAfterAll {
     "be able to run server streaming services" in {
 
       muProtoRPCServiceClient
-        .use(_.serverStreaming(b1).compile.toList)
+        .use(_.serverStreaming(b1).flatMap(_.compile.toList))
         .unsafeRunSync() shouldBe cList
 
     }
@@ -85,9 +85,8 @@ class RPCTests extends RpcBaseTestSuite with BeforeAndAfterAll {
         muProtoRPCServiceClient
           .use(
             _.serverStreamingWithError(E(a1, errorCode))
-              .handleErrorWith(ex => Stream(C(ex.getMessage, a1)))
-              .compile
-              .toList
+              .map(_.handleErrorWith(ex => Stream(C(ex.getMessage, a1))))
+              .flatMap(_.compile.toList)
           )
 
       clientProgram("SE")
@@ -110,7 +109,7 @@ class RPCTests extends RpcBaseTestSuite with BeforeAndAfterAll {
     "be able to run client bidirectional streaming services" in {
 
       muAvroRPCServiceClient
-        .use(_.biStreaming(Stream.fromIterator[IO](eList.iterator)).compile.toList)
+        .use(_.biStreaming(Stream.fromIterator[IO](eList.iterator)).flatMap(_.compile.toList))
         .unsafeRunSync()
         .distinct shouldBe eList
 
@@ -120,7 +119,7 @@ class RPCTests extends RpcBaseTestSuite with BeforeAndAfterAll {
 
       muAvroWithSchemaRPCServiceClient
         .use(
-          _.biStreamingWithSchema(Stream.fromIterator[IO](eList.iterator)).compile.toList
+          _.biStreamingWithSchema(Stream.fromIterator[IO](eList.iterator)).flatMap(_.compile.toList)
         )
         .unsafeRunSync()
         .distinct shouldBe eList
@@ -133,15 +132,16 @@ class RPCTests extends RpcBaseTestSuite with BeforeAndAfterAll {
         (
           muAvroRPCServiceClient.use(_.unary(a1)),
           muAvroWithSchemaRPCServiceClient.use(_.unaryWithSchema(a1)),
-          muProtoRPCServiceClient.use(_.serverStreaming(b1).compile.toList),
+          muProtoRPCServiceClient.use(_.serverStreaming(b1).flatMap(_.compile.toList)),
           muProtoRPCServiceClient.use(
             _.clientStreaming(Stream.fromIterator[IO](aList.iterator))
           ),
           muAvroRPCServiceClient.use(
-            _.biStreaming(Stream.fromIterator[IO](eList.iterator)).compile.toList
+            _.biStreaming(Stream.fromIterator[IO](eList.iterator)).flatMap(_.compile.toList)
           ),
           muAvroWithSchemaRPCServiceClient.use(
-            _.biStreamingWithSchema(Stream.fromIterator[IO](eList.iterator)).compile.toList
+            _.biStreamingWithSchema(Stream.fromIterator[IO](eList.iterator))
+              .flatMap(_.compile.toList)
           )
         )
 
@@ -175,7 +175,7 @@ class RPCTests extends RpcBaseTestSuite with BeforeAndAfterAll {
     "be able to run server streaming services" in {
 
       muCompressedProtoRPCServiceClient
-        .use(_.serverStreamingCompressed(b1).compile.toList)
+        .use(_.serverStreamingCompressed(b1).flatMap(_.compile.toList))
         .unsafeRunSync shouldBe cList
 
     }
@@ -191,7 +191,7 @@ class RPCTests extends RpcBaseTestSuite with BeforeAndAfterAll {
 
       muCompressedAvroRPCServiceClient
         .use(
-          _.biStreamingCompressed(Stream.fromIterator[IO](eList.iterator)).compile.toList
+          _.biStreamingCompressed(Stream.fromIterator[IO](eList.iterator)).flatMap(_.compile.toList)
         )
         .unsafeRunSync()
         .distinct shouldBe eList
@@ -202,7 +202,8 @@ class RPCTests extends RpcBaseTestSuite with BeforeAndAfterAll {
 
       muCompressedAvroWithSchemaRPCServiceClient
         .use(
-          _.biStreamingCompressedWithSchema(Stream.fromIterator[IO](eList.iterator)).compile.toList
+          _.biStreamingCompressedWithSchema(Stream.fromIterator[IO](eList.iterator))
+            .flatMap(_.compile.toList)
         )
         .unsafeRunSync()
         .distinct shouldBe eList
@@ -215,18 +216,21 @@ class RPCTests extends RpcBaseTestSuite with BeforeAndAfterAll {
         (
           muCompressedAvroRPCServiceClient.use(_.unaryCompressed(a1)),
           muCompressedAvroWithSchemaRPCServiceClient.use(_.unaryCompressedWithSchema(a1)),
-          muCompressedProtoRPCServiceClient.use(_.serverStreamingCompressed(b1).compile.toList),
+          muCompressedProtoRPCServiceClient.use(
+            _.serverStreamingCompressed(b1).flatMap(_.compile.toList)
+          ),
           muCompressedProtoRPCServiceClient.use(
             _.clientStreamingCompressed(Stream.fromIterator[IO](aList.iterator))
           ),
           muCompressedAvroRPCServiceClient.use(
-            _.biStreamingCompressed(Stream.fromIterator[IO](eList.iterator)).compile.toList
+            _.biStreamingCompressed(Stream.fromIterator[IO](eList.iterator))
+              .flatMap(_.compile.toList)
           ),
           muCompressedAvroWithSchemaRPCServiceClient
             .use(
               _.biStreamingCompressedWithSchema(
                 Stream.fromIterator[IO](eList.iterator)
-              ).compile.toList
+              ).flatMap(_.compile.toList)
             )
         )
 

--- a/modules/streaming/fs2/src/main/scala/higherkindness/mu/rpc/healthcheck/fs2/handler/HealthServiceFS2.scala
+++ b/modules/streaming/fs2/src/main/scala/higherkindness/mu/rpc/healthcheck/fs2/handler/HealthServiceFS2.scala
@@ -53,6 +53,6 @@ class HealthCheckServiceFS2Impl[F[_]: Sync](
       .update(_ + (newStatus.hc.nameService -> newStatus.status)) <*
       Stream.eval(watchTopic.publish1(newStatus)).compile.drain
 
-  def watch(service: HealthCheck): Stream[F, HealthStatus] =
-    watchTopic.subscribe(100).filter(_.hc === service)
+  def watch(service: HealthCheck): F[Stream[F, HealthStatus]] =
+    watchTopic.subscribe(100).filter(_.hc === service).pure[F]
 }

--- a/modules/streaming/fs2/src/main/scala/higherkindness/mu/rpc/healthcheck/fs2/serviceFS2.scala
+++ b/modules/streaming/fs2/src/main/scala/higherkindness/mu/rpc/healthcheck/fs2/serviceFS2.scala
@@ -32,6 +32,6 @@ object serviceFS2 {
     def checkAll(empty: Empty.type): F[AllStatus]
     def cleanAll(empty: Empty.type): F[Unit]
 
-    def watch(service: HealthCheck): Stream[F, HealthStatus]
+    def watch(service: HealthCheck): F[Stream[F, HealthStatus]]
   }
 }

--- a/modules/streaming/fs2/src/test/scala/higherkindness/mu/rpc/healthcheck/fs2/HealthCheckFS2Test.scala
+++ b/modules/streaming/fs2/src/test/scala/higherkindness/mu/rpc/healthcheck/fs2/HealthCheckFS2Test.scala
@@ -39,10 +39,12 @@ class HealthCheckFS2Test extends AnyWordSpec with Matchers {
     "work with setStatus and watch" in {
       {
         for {
-          hand <- handler
-          v1   <- hand.watch(hc0).take(1).compile.toList
-          _    <- hand.setStatus(HealthStatus(hc, ServerStatus("NOT_SERVING")))
-          v2   <- hand.watch(hc).take(1).compile.toList
+          hand    <- handler
+          stream1 <- hand.watch(hc0)
+          v1      <- stream1.take(1).compile.toList
+          _       <- hand.setStatus(HealthStatus(hc, ServerStatus("NOT_SERVING")))
+          stream2 <- hand.watch(hc)
+          v2      <- stream2.take(1).compile.toList
         } yield (v1, v2)
       }.unsafeRunSync() shouldBe Tuple2(
         List(HealthStatus(hc0, ServerStatus("UNKNOWN"))),

--- a/modules/streaming/monix/src/main/scala/higherkindness/mu/rpc/healthcheck/monix/handler/HealthServiceMonix.scala
+++ b/modules/streaming/monix/src/main/scala/higherkindness/mu/rpc/healthcheck/monix/handler/HealthServiceMonix.scala
@@ -54,7 +54,7 @@ class HealthCheckServiceMonixImpl[F[_]: Sync](
       .update(_ + (newStatus.hc.nameService -> newStatus.status)) <*
       Sync[F].delay(observer.onNext(newStatus))
 
-  override def watch(service: HealthCheck): Observable[HealthStatus] =
-    observable.filter(_.hc === service)
+  override def watch(service: HealthCheck): F[Observable[HealthStatus]] =
+    observable.filter(_.hc === service).pure[F]
 
 }

--- a/modules/streaming/monix/src/main/scala/higherkindness/mu/rpc/healthcheck/monix/serviceMonix.scala
+++ b/modules/streaming/monix/src/main/scala/higherkindness/mu/rpc/healthcheck/monix/serviceMonix.scala
@@ -32,6 +32,6 @@ object serviceMonix {
     def checkAll(empty: Empty.type): F[AllStatus]
     def cleanAll(empty: Empty.type): F[Unit]
 
-    def watch(service: HealthCheck): Observable[HealthStatus]
+    def watch(service: HealthCheck): F[Observable[HealthStatus]]
   }
 }

--- a/modules/streaming/monix/src/test/scala/higherkindness/mu/rpc/healthcheck/monix/HealthCheckMonixTest.scala
+++ b/modules/streaming/monix/src/test/scala/higherkindness/mu/rpc/healthcheck/monix/HealthCheckMonixTest.scala
@@ -36,9 +36,11 @@ class HealthCheckMonixTest extends AnyWordSpec with Matchers {
       {
         for {
           hand <- handler
-          v1   <- hand.watch(hc0).take(1).toListL.toAsync[IO]
+          obs1 <- hand.watch(hc0)
+          v1   <- obs1.take(1).toListL.toAsync[IO]
           _    <- hand.setStatus(HealthStatus(hc, ServerStatus("NOT_SERVING")))
-          v2   <- hand.watch(hc).take(1).toListL.toAsync[IO]
+          obs2 <- hand.watch(hc)
+          v2   <- obs2.take(1).toListL.toAsync[IO]
         } yield (v1, v2)
       }.unsafeRunSync() shouldBe Tuple2(
         List(HealthStatus(hc0, ServerStatus("UNKNOWN"))),


### PR DESCRIPTION
This is a change to the specification for Mu services. Previously, RPC endpoints with streaming responses were encoded as:

```scala
// with fs2
def foo(req: MyRequest): Stream[F, MyResponse]
// with Monix
def foo(req: MyRequest): Observable[MyResponse]
```

Now we require them to be inside `F[_]`, making them consistent with endpoints that return unary responses. They now look like:

```scala
// with fs2
def foo(req: MyRequest): F[Stream[F, MyResponse]]
// with Monix
def foo(req: MyRequest): F[Observable[MyResponse]]
```

This change is partly for consistency's sake, and mostly because it's required for distributed tracing (see #866 for details).

It's a breaking change for any users who use streaming responses, but the required fix in user code should be pretty small. On the server side, their service implementation just needs to lift the result into `F[_]` using `pure`. For example:

```scala
class MyServiceImpl[F[_]] extends MyService[F] {
  def foo(req: MyRequest): Stream[F, MyResponse] =
    Stream(MyResponse("hello"), MyResponse("world"))
}
```

becomes:

```scala
import cats.syntax.applicative._

class MyServiceImpl[F[_]: Applicative] extends MyService[F] {
  def foo(req: MyRequest): Stream[F, MyResponse] =
    Stream(MyResponse("hello"), MyResponse("world")).pure[F]
}
```


On the client side, they need to deal with the fact that the client method now returns `F[Stream[F, MyResponse]]` instead of a plain `Stream[F, MyResponse]`. With FS2, the easiest way to handle this is to use `Stream.eval` to make a stream-of-streams, then `flatten` it:

```scala
val res: F[Stream[F, MyResponse]] = client.foo(req)
val streamOfStreams: Stream[F, Stream[F, MyResponse]] = Stream.eval(res)
val stream: Stream[F, MyResponse] = streamOfStreams.flatten
```

With Monix, the corresponding incantation is:

```scala
val res: F[Observable[MyResponse]] = client.foo(req)
val nestedObs: Observable[Observable[MyResponse]] = Observable.from(res)
val obs: Observable[MyResponse] = obs.flatten
```

Potentially we could publish scalafix rewrites to help users migrate, but I'm not sure it's worth the effort.

## Other changes

As part of this work I had to refactor the macro code slightly. I also added a few more compile-time checks to the macro, and I ended up improving the support for `Empty` requests and responses in the HTTP-related macro code.