### PR TITLE
Remove sbt-scripted plugin

### DIFF
--- a/project/ProjectPlugin.scala
+++ b/project/ProjectPlugin.scala
@@ -1,6 +1,5 @@
 import microsites.MicrositesPlugin.autoImport._
 import sbt.Keys._
-import sbt.ScriptedPlugin.autoImport._
 import sbt._
 import sbtorgpolicies.OrgPoliciesPlugin
 import sbtorgpolicies.OrgPoliciesPlugin.autoImport._

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -6,5 +6,3 @@ addSbtPlugin("com.eed3si9n"              % "sbt-buildinfo"    % "0.9.0")
 addSbtPlugin("pl.project13.scala"        % "sbt-jmh"          % "0.3.7")
 addSbtPlugin("org.scoverage"             % "sbt-scoverage"    % "1.6.1")
 addSbtPlugin("io.github.davidgregory084" % "sbt-tpolecat"     % "0.1.11")
-
-libraryDependencies += "org.scala-sbt" %% "scripted-plugin" % sbtVersion.value


### PR DESCRIPTION
It was used by the sbt-mu-srcgen tests. That module has been moved to
its own repo.


## What this does?
_Changes, features, fixes ..._

## Checklist

- [ ] Reviewed the diff to look for typos, println and format errors.
- [ ] Updated the docs accordingly.