### PR TITLE
Fix a bunch of compiler warnings

### DIFF
--- a/modules/channel/src/main/scala/higherkindness/mu/rpc/channel/package.scala
+++ b/modules/channel/src/main/scala/higherkindness/mu/rpc/channel/package.scala
@@ -18,7 +18,7 @@ package higherkindness.mu.rpc
 
 import cats.data.Kleisli
 
-import scala.collection.JavaConverters._
+import scala.jdk.CollectionConverters._
 import io.grpc._
 
 package object channel {

--- a/modules/channel/src/test/scala/higherkindness/mu/rpc/channel/metrics/MonitoringChannelInterceptorTests.scala
+++ b/modules/channel/src/test/scala/higherkindness/mu/rpc/channel/metrics/MonitoringChannelInterceptorTests.scala
@@ -17,7 +17,6 @@
 package higherkindness.mu.rpc.channel.metrics
 
 import cats.effect.{IO, Resource}
-import cats.syntax.apply._
 import higherkindness.mu.rpc.common.{A => _, _}
 import higherkindness.mu.rpc.common.util.FakeClock
 import higherkindness.mu.rpc.internal.interceptors.GrpcMethodInfo

--- a/modules/kafka/src/main/scala/higherkindness/mu/rpc/kafka/kafkaManagementService.scala
+++ b/modules/kafka/src/main/scala/higherkindness/mu/rpc/kafka/kafkaManagementService.scala
@@ -41,7 +41,7 @@ import org.apache.kafka.clients.admin.{
 import org.apache.kafka.clients.consumer.{OffsetAndMetadata => KOffsetAndMetadata}
 import pbdirect.Pos
 
-import scala.collection.JavaConverters._
+import scala.jdk.CollectionConverters._
 
 object kafkaManagementService {
   final case class CreatePartitionsRequest(name: String, numPartitions: Int)

--- a/modules/metrics/dropwizard/src/test/scala/higherkindness/mu/rpc/dropwizard/DropwizardMetricsTests.scala
+++ b/modules/metrics/dropwizard/src/test/scala/higherkindness/mu/rpc/dropwizard/DropwizardMetricsTests.scala
@@ -28,7 +28,7 @@ import io.grpc.Status
 import org.scalacheck.{Gen, Properties}
 import org.scalacheck.Prop._
 
-import scala.collection.JavaConverters._
+import scala.jdk.CollectionConverters._
 
 object DropwizardMetricsTests extends Properties("DropWizardMetrics") {
 

--- a/modules/metrics/prometheus/src/test/scala/higherkindness/mu/rpc/prometheus/PrometheusMetricsTests.scala
+++ b/modules/metrics/prometheus/src/test/scala/higherkindness/mu/rpc/prometheus/PrometheusMetricsTests.scala
@@ -26,7 +26,7 @@ import io.prometheus.client.{Collector, CollectorRegistry}
 import org.scalacheck.Prop.forAllNoShrink
 import org.scalacheck.{Gen, Properties}
 
-import scala.collection.JavaConverters._
+import scala.jdk.CollectionConverters._
 
 class PrometheusMetricsTests extends Properties("PrometheusMetrics") {
 

--- a/modules/server/src/main/scala/higherkindness/mu/rpc/server/handlers/GrpcServerHandler.scala
+++ b/modules/server/src/main/scala/higherkindness/mu/rpc/server/handlers/GrpcServerHandler.scala
@@ -23,7 +23,7 @@ import cats.syntax.functor._
 import higherkindness.mu.rpc.server.{GrpcServer, GrpcServerOps}
 import io.grpc.{Server, ServerServiceDefinition}
 
-import scala.collection.JavaConverters._
+import scala.jdk.CollectionConverters._
 import scala.concurrent.duration.TimeUnit
 
 private[handlers] class GrpcServerHandler[F[_]: Sync] private[GrpcServerHandler] ()

--- a/modules/server/src/test/scala/higherkindness/mu/rpc/server/RpcServerTestSuite.scala
+++ b/modules/server/src/test/scala/higherkindness/mu/rpc/server/RpcServerTestSuite.scala
@@ -32,7 +32,7 @@ import io.netty.channel.local.LocalServerChannel
 import io.netty.channel.nio.NioEventLoopGroup
 import io.netty.handler.ssl.SslContext
 
-import scala.collection.JavaConverters._
+import scala.jdk.CollectionConverters._
 import scala.concurrent.duration.TimeUnit
 
 trait RpcServerTestSuite extends RpcBaseTestSuite {

--- a/modules/server/src/test/scala/higherkindness/mu/rpc/server/metrics/MetricsServerInterceptorTests.scala
+++ b/modules/server/src/test/scala/higherkindness/mu/rpc/server/metrics/MetricsServerInterceptorTests.scala
@@ -17,7 +17,6 @@
 package higherkindness.mu.rpc.server.metrics
 
 import cats.effect.{Clock, IO, Resource}
-import cats.syntax.apply._
 import higherkindness.mu.rpc.common.{A => _, _}
 import higherkindness.mu.rpc.common.util.FakeClock
 import higherkindness.mu.rpc.internal.interceptors.GrpcMethodInfo

--- a/modules/testing/src/test/scala/higherkindness/mu/rpc/testing/ServersTests.scala
+++ b/modules/testing/src/test/scala/higherkindness/mu/rpc/testing/ServersTests.scala
@@ -22,7 +22,7 @@ import org.scalatest._
 import org.scalatestplus.scalacheck.Checkers
 import org.scalacheck.Prop._
 
-import scala.collection.JavaConverters._
+import scala.jdk.CollectionConverters._
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
 

--- a/project/ProjectPlugin.scala
+++ b/project/ProjectPlugin.scala
@@ -213,10 +213,11 @@ object ProjectPlugin extends AutoPlugin {
 
     lazy val testingSettings: Seq[Def.Setting[_]] = Seq(
       libraryDependencies ++= Seq(
-        "io.grpc"           % "grpc-testing"              % V.grpc,
-        "org.typelevel"     %% "cats-effect"              % V.catsEffect,
-        "org.scalacheck"    %% "scalacheck"               % V.scalacheck % Test,
-        "org.scalatestplus" %% "scalatestplus-scalacheck" % V.scalatestplusScheck % Test
+        "io.grpc"                % "grpc-testing"              % V.grpc,
+        "org.typelevel"          %% "cats-effect"              % V.catsEffect,
+        "org.scalacheck"         %% "scalacheck"               % V.scalacheck % Test,
+        "org.scalatestplus"      %% "scalatestplus-scalacheck" % V.scalatestplusScheck % Test,
+        "org.scala-lang.modules" %% "scala-collection-compat"  % V.scalaCollectionCompat % Test
       )
     )
 


### PR DESCRIPTION
## What this does?

Use scala-collection-compat to fix deprecation warnings.

## Checklist

- [ ] Reviewed the diff to look for typos, println and format errors.
- [ ] Updated the docs accordingly.

