### PR TITLE
Remove annotations

### DIFF
--- a/modules/service/src/main/scala/higherkindness/mu/rpc/protocol/protocol.scala
+++ b/modules/service/src/main/scala/higherkindness/mu/rpc/protocol/protocol.scala
@@ -14,10 +14,7 @@
  * limitations under the License.
  */
 
-package higherkindness.mu.rpc
-package protocol
-
-import scala.annotation.StaticAnnotation
+package higherkindness.mu.rpc.protocol
 
 sealed trait StreamingType         extends Product with Serializable
 case object RequestStreaming       extends StreamingType
@@ -37,9 +34,5 @@ case object Gzip                      extends CompressionType
 sealed abstract class MethodNameStyle extends Product with Serializable
 case object Unchanged                 extends MethodNameStyle
 case object Capitalize                extends MethodNameStyle
-
-class option(name: String, value: Any) extends StaticAnnotation
-class outputPackage(value: String)     extends StaticAnnotation
-class outputName(value: String)        extends StaticAnnotation
 
 object Empty


### PR DESCRIPTION
The `@option`, `@outputPackage` and `@outputName` annotations were left over from the old IDL generation feature.

To avoid sbt-mu-srcgen generating code containing `@option` annotations, there is a dependency on:

1. https://github.com/higherkindness/skeuomorph/pull/275 being merged
2. new version of skeuomorph being released
3. sbt-mu-srcgen's skeuomorph dependency being upgraded

## What this does?
_Changes, features, fixes ..._

## Checklist

- [ ] Reviewed the diff to look for typos, println and format errors.
- [ ] Updated the docs accordingly.

