### PR TITLE
Enable -Xfatal-warnings for Scala 2.13

### DIFF
--- a/modules/server/src/main/scala/higherkindness/mu/rpc/server/handlers/GrpcServerHandler.scala
+++ b/modules/server/src/main/scala/higherkindness/mu/rpc/server/handlers/GrpcServerHandler.scala
@@ -29,7 +29,7 @@ import scala.concurrent.duration.TimeUnit
 private[handlers] class GrpcServerHandler[F[_]: Sync] private[GrpcServerHandler] ()
     extends GrpcServer[GrpcServerOps[F, ?]] {
 
-  def start: GrpcServerOps[F, Unit] =
+  def start(): GrpcServerOps[F, Unit] =
     captureWithServer(_.start()).void
 
   def getPort: GrpcServerOps[F, Int] = captureWithServer(_.getPort)
@@ -43,10 +43,10 @@ private[handlers] class GrpcServerHandler[F[_]: Sync] private[GrpcServerHandler]
   def getMutableServices: GrpcServerOps[F, List[ServerServiceDefinition]] =
     captureWithServer(_.getMutableServices.asScala.toList)
 
-  def shutdown: GrpcServerOps[F, Unit] =
+  def shutdown(): GrpcServerOps[F, Unit] =
     captureWithServer(_.shutdown()).void
 
-  def shutdownNow: GrpcServerOps[F, Unit] =
+  def shutdownNow(): GrpcServerOps[F, Unit] =
     captureWithServer(_.shutdownNow()).void
 
   def isShutdown: GrpcServerOps[F, Boolean] = captureWithServer(_.isShutdown)
@@ -56,7 +56,7 @@ private[handlers] class GrpcServerHandler[F[_]: Sync] private[GrpcServerHandler]
   def awaitTerminationTimeout(timeout: Long, unit: TimeUnit): GrpcServerOps[F, Boolean] =
     captureWithServer(_.awaitTermination(timeout, unit))
 
-  def awaitTermination: GrpcServerOps[F, Unit] = captureWithServer(_.awaitTermination())
+  def awaitTermination(): GrpcServerOps[F, Unit] = captureWithServer(_.awaitTermination())
 
   private[this] def captureWithServer[A](f: Server => A): GrpcServerOps[F, A] =
     Kleisli(s => Sync[F].delay(f(s)))

--- a/modules/tests/src/test/scala/higherkindness/mu/rpc/server/metrics/MetricsServerInterceptorTests.scala
+++ b/modules/tests/src/test/scala/higherkindness/mu/rpc/server/metrics/MetricsServerInterceptorTests.scala
@@ -16,7 +16,7 @@
 
 package higherkindness.mu.rpc.server.metrics
 
-import cats.effect.{Clock, IO, Resource}
+import cats.effect.{IO, Resource}
 import higherkindness.mu.rpc.common.{A => _, _}
 import higherkindness.mu.rpc.common.util.FakeClock
 import higherkindness.mu.rpc.internal.interceptors.GrpcMethodInfo
@@ -70,7 +70,6 @@ class MetricsServerInterceptorTests extends RpcBaseTestSuite {
   private[this] def makeProtoCalls[A](metricsOps: MetricsOps[IO])(
       f: ProtoRPCService[IO] => IO[A]
   )(implicit H: ProtoRPCService[IO], clock: FakeClock[IO]): IO[Either[Throwable, A]] = {
-    implicit val _: Clock[IO] = clock
     withServerChannel[IO](
       service = ProtoRPCService
         .bindService[IO]

--- a/project/ProjectPlugin.scala
+++ b/project/ProjectPlugin.scala
@@ -315,7 +315,10 @@ object ProjectPlugin extends AutoPlugin {
   override def projectSettings: Seq[Def.Setting[_]] =
     Seq(
       crossScalaVersions := Seq(V.scala212, V.scala213),
-      scalacOptions --= Seq("-Xfuture", "-Xfatal-warnings"),
+      scalacOptions --= {
+        if (isOlderScalaVersion(scalaVersion.value)) Seq("-Xfatal-warnings")
+        else Nil
+      },
       Test / fork := true,
       compileOrder in Compile := CompileOrder.JavaThenScala,
       coverageFailOnMinimum := false,


### PR DESCRIPTION
Now that those annotations have been deleted (#908), we can re-enable `-Xfatal-warnings` for Scala 2.13.x.

## What this does?
_Changes, features, fixes ..._

## Checklist

- [ ] Reviewed the diff to look for typos, println and format errors.
- [ ] Updated the docs accordingly.