### PR TITLE
Fix invalid scaladoc

### DIFF
--- a/modules/server/src/main/scala/higherkindness/mu/rpc/server/GrpcServer.scala
+++ b/modules/server/src/main/scala/higherkindness/mu/rpc/server/GrpcServer.scala
@@ -95,7 +95,7 @@ object GrpcServer {
    * Build a [[GrpcServer]] that uses the default network transport layer.
    *
    * The transport layer will be Netty, unless you have written your own
-   * [[io.grpc.ServerProvider]] implementation and added it to the classpath.
+   * `io.grpc.ServerProvider` implementation and added it to the classpath.
    */
   def default[F[_]](port: Int, configList: List[GrpcConfig])(implicit
       F: Sync[F]
@@ -120,7 +120,7 @@ object GrpcServer {
     } yield fromServer[F](server)
 
   /**
-   * Helper to convert an [[io.grpc.Server]] into a [[GrpcServer]].
+   * Helper to convert an `io.grpc.Server` into a [[GrpcServer]].
    */
   def fromServer[F[_]: Sync](server: Server): GrpcServer[F] =
     handlers.GrpcServerHandler[F].mapK(λ[GrpcServerOps[F, ?] ~> F](_.run(server)))

--- a/modules/service/src/main/scala/higherkindness/mu/rpc/internal/service/makro/TypeAnalysis.scala
+++ b/modules/service/src/main/scala/higherkindness/mu/rpc/internal/service/makro/TypeAnalysis.scala
@@ -23,20 +23,20 @@ class TypeAnalysis[C <: Context](val c: C) {
   import c.universe._
 
   /**
-   * @originalType The original type written by the user.
-   *               For a request type, this will be e.g. `MyRequest` or `Stream[F, MyRequest]`
-   *               or `Observable[MyRequest]`.
-   *               For a response type, it will be inside an effect type,
-   *               e.g. `F[MyResponse]` or `F[Stream[F, MyResponse]]` or `F[Observable[MyResponse]]`
+   * @param originalType The original type written by the user.
+   *                     For a request type, this will be e.g.
+   *                     `MyRequest` or `Stream[F, MyRequest]` or `Observable[MyRequest]`.
+   *                     For a response type, it will be inside an effect type,
+   *                     e.g. `F[MyResponse]` or `F[Stream[F, MyResponse]]` or `F[Observable[MyResponse]]`
    *
-   * @unwrappedType The type, with any surrounding effect type stripped.
-   *                e.g. `MyRequest` or `Stream[F, MyRequest]` or `Observable[MyRequest]`
-   *                For a request type, `unwrappedType` == `originalType`.
+   * @param unwrappedType The type, with any surrounding effect type stripped.
+   *                      e.g. `MyRequest` or `Stream[F, MyRequest]` or `Observable[MyRequest]`
+   *                      For a request type, `unwrappedType` == `originalType`.
    *
-   * @messageType The type of the message in a request/response.
-   *              For non-streaming request/responses, `messageType` == `unwrappedType`.
-   *              For streaming request/responses, `messageType` is the type of the stream elements.
-   *              e.g. if `originalType` is `F[Stream[F, MyResponse]]` then `messageType` is `MyResponse`.
+   * @param messageType The type of the message in a request/response.
+   *                    For non-streaming request/responses, `messageType` == `unwrappedType`.
+   *                    For streaming request/responses, `messageType` is the type of the stream elements.
+   *                    e.g. if `originalType` is `F[Stream[F, MyResponse]]` then `messageType` is `MyResponse`.
    */
   abstract class TypeTypology(
       val originalType: Tree,


### PR DESCRIPTION
These were triggering `-Xfatal-warnings` and failing the build


## What this does?
_Changes, features, fixes ..._

## Checklist

- [ ] Reviewed the diff to look for typos, println and format errors.
- [ ] Updated the docs accordingly.