### PR TITLE
Upgrade integration tests to Mu-Haskell v0.3

### DIFF
--- a/modules/haskell-integration-tests/README.md
+++ b/modules/haskell-integration-tests/README.md
@@ -31,11 +31,14 @@ This relies on the test knowing what responses the Mu-Haskell server will send.
 The Haskell code is managed as a Stack project in the `mu-haskell-client-server`
 directory.
 
-The Stack project is made up of 3 modules:
+The Stack project is made up of 5 modules:
 
-* `protocol`, where types are generated from the `weather.proto` file
-* `server`
-* `client`
+* `protocol`, where types are generated from the `weather.proto` and
+  `weather.avdl` files
+* `protobuf-server`
+* `protobuf-client`
+* `avro-server`
+* `avro-client`
 
 To build the server and client executables:
 

--- a/modules/haskell-integration-tests/README.md
+++ b/modules/haskell-integration-tests/README.md
@@ -59,7 +59,7 @@ much faster.
 
 ## How to make a change
 
-1. Make any necessary changes to the Haskell code in `mu-haskell-cliient-server`.
+1. Make any necessary changes to the Haskell code in `mu-haskell-client-server`.
 2. Rebuild the Haskell Docker image.
 3. Make any necessary changes to the Scala code.
 4. Run the tests to check they work: `sbt haskell-integration-tests/test`

--- a/modules/haskell-integration-tests/mu-haskell-client-server/Dockerfile
+++ b/modules/haskell-integration-tests/mu-haskell-client-server/Dockerfile
@@ -4,7 +4,7 @@ RUN mkdir /opt/build
 RUN mkdir /opt/build/bin
 COPY . /opt/build
 RUN cd /opt/build && stack build --system-ghc --copy-bins --local-bin-path /opt/build/bin
-FROM ubuntu:19.04
+FROM ubuntu:20.04
 RUN mkdir -p /opt/mu-haskell-client-server
 WORKDIR /opt/mu-haskell-client-server
 RUN apt-get update && apt-get install -y \

--- a/modules/haskell-integration-tests/mu-haskell-client-server/Dockerfile
+++ b/modules/haskell-integration-tests/mu-haskell-client-server/Dockerfile
@@ -1,5 +1,5 @@
 FROM fpco/stack-build:lts-14.27 as build
-COPY --from=mu_haskell_warm_dot_stack /root/.stack /root/.stack
+COPY --from=cb372/mu-haskell-warm-dot-stack /root/.stack /root/.stack
 RUN mkdir /opt/build
 RUN mkdir /opt/build/bin
 COPY . /opt/build

--- a/modules/haskell-integration-tests/mu-haskell-client-server/avro-client/Main.hs
+++ b/modules/haskell-integration-tests/mu-haskell-client-server/avro-client/Main.hs
@@ -1,10 +1,6 @@
 {-# language DataKinds             #-}
-{-# language FlexibleContexts      #-}
-{-# language PartialTypeSignatures #-}
 {-# language OverloadedLabels      #-}
-{-# language OverloadedStrings     #-}
 {-# language TypeApplications      #-}
-{-# OPTIONS_GHC -fno-warn-partial-type-signatures #-}
 
 module Main where
 
@@ -16,7 +12,6 @@ import           Data.ByteString.Char8         as BS
                                                 ( unpack )
 import           Data.ByteString.Lazy          as LBS
                                                 ( toStrict )
-import           Data.Functor.Identity
 import           Data.List                      ( intercalate )
 import           Data.Maybe                     ( fromMaybe )
 import           Data.Text                     as T

--- a/modules/haskell-integration-tests/mu-haskell-client-server/avro-client/Main.hs
+++ b/modules/haskell-integration-tests/mu-haskell-client-server/avro-client/Main.hs
@@ -48,18 +48,19 @@ ping client = do
 getForecast
   :: GRpcConnection WeatherService 'MsgAvro -> String -> String -> IO ()
 getForecast client city days = do
-  GRpcOk resp <- (client ^. #getForecast) req
+  resp <- (client ^. #getForecast) req
   putStrLn $ showGetForecastResponse resp
  where
   c   = T.pack city
   d   = fromMaybe 5 $ readMaybe days
   req = record (c, d)
 
-showGetForecastResponse :: GetForecastResponse -> String
-showGetForecastResponse resp = lastUpdated ++ " " ++ dailyForecasts
+showGetForecastResponse :: GRpcReply GetForecastResponse -> String
+showGetForecastResponse (GRpcOk resp) = lastUpdated ++ " " ++ dailyForecasts
  where
   lastUpdated    = T.unpack (resp ^. #last_updated)
   dailyForecasts = toJsonString (resp ^. #daily_forecasts)
+showGetForecastResponse errorResp = show errorResp
 
 toJsonString :: A.ToJSON a => a -> String
 toJsonString = BS.unpack . LBS.toStrict . A.encode

--- a/modules/haskell-integration-tests/mu-haskell-client-server/avro-server/Main.hs
+++ b/modules/haskell-integration-tests/mu-haskell-client-server/avro-server/Main.hs
@@ -8,7 +8,6 @@
 
 module Main where
 
-import           Data.Functor.Identity
 import           Data.Maybe                     ( fromMaybe )
 import           Data.Text                     as T
                                                 ( Text )
@@ -37,5 +36,8 @@ lastUpdated = "2020-03-20T12:00:00Z"
 sunnyDays :: Int -> [Weather]
 sunnyDays n = replicate n (enum @"SUNNY")
 
-server :: (MonadServer m) => ServerT Identity WeatherService m _
-server = Server (getForecast :<|>: ping :<|>: H0)
+server :: (MonadServer m) => SingleServerT WeatherService m _
+server = singleService
+  ( method @"getForecast" getForecast
+  , method @"ping" ping
+  )

--- a/modules/haskell-integration-tests/mu-haskell-client-server/build.sh
+++ b/modules/haskell-integration-tests/mu-haskell-client-server/build.sh
@@ -1,10 +1,10 @@
 #!/usr/bin/env bash
 
-if [ -z "$(docker images -q mu_haskell_warm_dot_stack)" ]; then
+if [ -z "$(docker images -q cb372/mu-haskell-warm-dot-stack)" ]; then
   echo "Building an image with a warm '~/.stack' directory."
   echo "This will take ages, but we only need to do it once."
   echo
-  docker build -t mu_haskell_warm_dot_stack -f Dockerfile.warm_dot_stack .
+  docker build -t cb372/mu-haskell-warm-dot-stack -f Dockerfile.warm_dot_stack .
 fi
 
 docker build -t cb372/mu-scala-haskell-integration-tests .

--- a/modules/haskell-integration-tests/mu-haskell-client-server/build.sh
+++ b/modules/haskell-integration-tests/mu-haskell-client-server/build.sh
@@ -1,10 +1,5 @@
 #!/usr/bin/env bash
 
-if [ -z "$(docker images -q cb372/mu-haskell-warm-dot-stack)" ]; then
-  echo "Building an image with a warm '~/.stack' directory."
-  echo "This will take ages, but we only need to do it once."
-  echo
-  docker build -t cb372/mu-haskell-warm-dot-stack -f Dockerfile.warm_dot_stack .
-fi
+docker pull cb372/mu-haskell-warm-dot-stack
 
 docker build -t cb372/mu-scala-haskell-integration-tests .

--- a/modules/haskell-integration-tests/mu-haskell-client-server/mu-haskell-client-server.cabal
+++ b/modules/haskell-integration-tests/mu-haskell-client-server/mu-haskell-client-server.cabal
@@ -17,11 +17,11 @@ library
   default-language:    Haskell2010
   build-depends:       base >= 4.12 && < 5
                      , text
-                     , mu-schema >= 0.2.0
-                     , mu-optics >= 0.2.0
-                     , mu-rpc >= 0.2.0
-                     , mu-avro >= 0.2.0
-                     , mu-protobuf >= 0.2.0
+                     , mu-schema >= 0.3.0
+                     , mu-optics >= 0.3.0
+                     , mu-rpc >= 0.3.0
+                     , mu-avro >= 0.3.0
+                     , mu-protobuf >= 0.3.0
 
 executable avro-server
   hs-source-dirs:      avro-server
@@ -29,11 +29,11 @@ executable avro-server
   default-language:    Haskell2010
   build-depends:       base >= 4.12 && < 5
                      , text
-                     , mu-schema >= 0.2.0
-                     , mu-optics >= 0.2.0
-                     , mu-rpc >= 0.2.0
-                     , mu-avro >= 0.2.0
-                     , mu-grpc-server >= 0.2.0
+                     , mu-schema >= 0.3.0
+                     , mu-optics >= 0.3.0
+                     , mu-rpc >= 0.3.0
+                     , mu-avro >= 0.3.0
+                     , mu-grpc-server >= 0.3.0
                      , mu-haskell-client-server
 
 executable avro-client
@@ -44,11 +44,11 @@ executable avro-client
                      , text
                      , aeson >= 1.4.6.0
                      , bytestring >= 0.10.8.2
-                     , mu-schema >= 0.2.0
-                     , mu-optics >= 0.2.0
-                     , mu-rpc >= 0.2.0
-                     , mu-avro >= 0.2.0
-                     , mu-grpc-client >= 0.2.0
+                     , mu-schema >= 0.3.0
+                     , mu-optics >= 0.3.0
+                     , mu-rpc >= 0.3.0
+                     , mu-avro >= 0.3.0
+                     , mu-grpc-client >= 0.3.0
                      , http2-client-grpc >= 0.8.0.0
                      , mu-haskell-client-server
 
@@ -58,11 +58,11 @@ executable protobuf-server
   default-language:    Haskell2010
   build-depends:       base >= 4.12 && < 5
                      , text
-                     , mu-schema >= 0.2.0
-                     , mu-optics >= 0.2.0
-                     , mu-rpc >= 0.2.0
-                     , mu-protobuf >= 0.2.0
-                     , mu-grpc-server >= 0.2.0
+                     , mu-schema >= 0.3.0
+                     , mu-optics >= 0.3.0
+                     , mu-rpc >= 0.3.0
+                     , mu-protobuf >= 0.3.0
+                     , mu-grpc-server >= 0.3.0
                      , conduit >= 1.3.1.2
                      , mu-haskell-client-server
 
@@ -74,11 +74,11 @@ executable protobuf-client
                      , text
                      , aeson >= 1.4.6.0
                      , bytestring >= 0.10.8.2
-                     , mu-schema >= 0.2.0
-                     , mu-optics >= 0.2.0
-                     , mu-rpc >= 0.2.0
-                     , mu-protobuf >= 0.2.0
-                     , mu-grpc-client >= 0.2.0
+                     , mu-schema >= 0.3.0
+                     , mu-optics >= 0.3.0
+                     , mu-rpc >= 0.3.0
+                     , mu-protobuf >= 0.3.0
+                     , mu-grpc-client >= 0.3.0
                      , conduit >= 1.3.1.2
                      , http2-client-grpc >= 0.8.0.0
                      , mu-haskell-client-server

--- a/modules/haskell-integration-tests/mu-haskell-client-server/protobuf-client/Main.hs
+++ b/modules/haskell-integration-tests/mu-haskell-client-server/protobuf-client/Main.hs
@@ -89,7 +89,7 @@ subscribeToRainEvents client city = do
     .| C.mapM_ putStrLn
  where
   req = record1 $ T.pack city
-  extractEventType (GRpcOk reply) = reply ^. #event_type
+  extractEventType (GRpcOk reply) = fromMaybe started $ reply ^. #event_type
 
 toJsonString :: A.ToJSON a => a -> String
 toJsonString = BS.unpack . LBS.toStrict . A.encode

--- a/modules/haskell-integration-tests/mu-haskell-client-server/protobuf-server/Main.hs
+++ b/modules/haskell-integration-tests/mu-haskell-client-server/protobuf-server/Main.hs
@@ -13,7 +13,6 @@ import qualified Data.Conduit.Combinators      as C
 import           Data.Monoid                   as M
 import           Data.Text                     as T
                                                 ( Text )
-import           Control.Monad.IO.Class         ( liftIO )
 import           Mu.GRpc.Server
 import           Mu.Server
 import           Mu.Schema.Optics
@@ -47,6 +46,7 @@ publishRainEvents source = toResponse <$> countRainStartedEvents
   countRainStartedEvents = runConduit $ source .| C.foldMap countMsg
   countMsg msg = countEvent $ msg ^. #event_type
   countEvent (Just x) | x == started = M.Sum 1
+  countEvent Nothing                 = M.Sum 1
   countEvent _                       = M.Sum 0
 
 subscribeToRainEvents

--- a/modules/haskell-integration-tests/mu-haskell-client-server/protocol/AvroProtocol.hs
+++ b/modules/haskell-integration-tests/mu-haskell-client-server/protocol/AvroProtocol.hs
@@ -23,9 +23,9 @@ import           Mu.Schema.Optics
 avdl "WeatherProtocol" "WeatherService" "." "weather.avdl"
 
 type GetForecastRequest
-  = Term Identity WeatherProtocol (WeatherProtocol :/: "GetForecastRequest")
+  = Term WeatherProtocol (WeatherProtocol :/: "GetForecastRequest")
 
-type Weather = Term Identity WeatherProtocol (WeatherProtocol :/: "Weather")
+type Weather = Term WeatherProtocol (WeatherProtocol :/: "Weather")
 
 type GetForecastResponse
-  = Term Identity WeatherProtocol (WeatherProtocol :/: "GetForecastResponse")
+  = Term WeatherProtocol (WeatherProtocol :/: "GetForecastResponse")

--- a/modules/haskell-integration-tests/mu-haskell-client-server/protocol/ProtobufProtocol.hs
+++ b/modules/haskell-integration-tests/mu-haskell-client-server/protocol/ProtobufProtocol.hs
@@ -23,17 +23,16 @@ import           Mu.Schema.Optics
 grpc "WeatherProtocol" id "weather.proto"
 
 type GetForecastRequest
-  = Term Maybe WeatherProtocol (WeatherProtocol :/: "GetForecastRequest")
+  = Term WeatherProtocol (WeatherProtocol :/: "GetForecastRequest")
 
-type Weather = Term Maybe WeatherProtocol (WeatherProtocol :/: "Weather")
+type Weather = Term WeatherProtocol (WeatherProtocol :/: "Weather")
 
 type GetForecastResponse
-  = Term Maybe WeatherProtocol (WeatherProtocol :/: "GetForecastResponse")
+  = Term WeatherProtocol (WeatherProtocol :/: "GetForecastResponse")
 
-type RainEvent = Term Maybe WeatherProtocol (WeatherProtocol :/: "RainEvent")
+type RainEvent = Term WeatherProtocol (WeatherProtocol :/: "RainEvent")
 
-type RainEventType
-  = Term Maybe WeatherProtocol (WeatherProtocol :/: "RainEventType")
+type RainEventType = Term WeatherProtocol (WeatherProtocol :/: "RainEventType")
 
 started :: RainEventType
 started = enum @"STARTED"
@@ -42,11 +41,8 @@ stopped :: RainEventType
 stopped = enum @"STOPPED"
 
 type RainSummaryResponse
-  = Term Maybe WeatherProtocol (WeatherProtocol :/: "RainSummaryResponse")
+  = Term WeatherProtocol (WeatherProtocol :/: "RainSummaryResponse")
 
 type SubscribeToRainEventsRequest
-  = Term
-      Maybe
-      WeatherProtocol
-      (WeatherProtocol :/: "SubscribeToRainEventsRequest")
+  = Term WeatherProtocol (WeatherProtocol :/: "SubscribeToRainEventsRequest")
 

--- a/modules/haskell-integration-tests/mu-haskell-client-server/stack.yaml
+++ b/modules/haskell-integration-tests/mu-haskell-client-server/stack.yaml
@@ -1,26 +1,57 @@
-resolver: lts-14.27
+# TODO update this file when mu-haskell is released
+#resolver: lts-15.5
+#allow-newer: true
+#extra-deps:
+## mu
+#- mu-schema-0.3.1.0
+#- mu-rpc-0.3.1.0
+#- mu-optics-0.3.1.0
+#- mu-avro-0.3.1.0
+#- mu-protobuf-0.3.1.0
+#- mu-grpc-client-0.3.1.0
+#- mu-grpc-server-0.3.1.0
+#- mu-grpc-common-0.3.1.0
+#- compendium-client-0.2.0.0
+## dependencies of mu
+#- http2-client-0.9.0.0
+#- http2-client-grpc-0.8.0.0
+#- http2-grpc-proto3-wire-0.1.0.0
+#- http2-grpc-types-0.5.0.0
+#- proto3-wire-1.1.0
+#- warp-grpc-0.4.0.1
+#- hw-kafka-client-3.0.0
+#- hw-kafka-conduit-2.6.0
+#- git: https://github.com/hasura/graphql-parser-hs.git
+#  commit: 1380495a7b3269b70a7ab3081d745a5f54171a9c
+#- avro-0.5.1.0
+#- language-avro-0.1.3.1
+
+resolver: lts-15.5
 allow-newer: true
 extra-deps:
 # mu
-- mu-schema-0.3.0.0
-- mu-rpc-0.3.0.0
-- mu-optics-0.3.0.0
-- mu-avro-0.3.0.0
-- mu-protobuf-0.3.0.0
-- mu-grpc-client-0.3.0.0
-- mu-grpc-server-0.3.0.0
-- mu-grpc-common-0.3.0.0
+- git: https://github.com/higherkindness/mu-haskell.git
+  commit: e4ec9802643d9a2e3da9c6964dddc1861368401a
+  subdirs:
+  - core/schema
+  - core/rpc
+  - core/optics
+  - adapter/avro
+  - adapter/protobuf
+  - grpc/common
+  - grpc/server
+  - grpc/client
 - compendium-client-0.2.0.0
-# dependencies of mu
+# dependencies of mu
 - http2-client-0.9.0.0
 - http2-client-grpc-0.8.0.0
-- http2-grpc-types-0.5.0.0
 - http2-grpc-proto3-wire-0.1.0.0
-- warp-grpc-0.4.0.1
+- http2-grpc-types-0.5.0.0
 - proto3-wire-1.1.0
-- language-protobuf-1.0.1
-- language-avro-0.1.3.1
+- warp-grpc-0.4.0.1
+- hw-kafka-client-3.0.0
+- hw-kafka-conduit-2.6.0
+- git: https://github.com/hasura/graphql-parser-hs.git
+  commit: 1380495a7b3269b70a7ab3081d745a5f54171a9c
 - avro-0.5.1.0
-- HasBigDecimal-0.1.1
-- optics-core-0.2
-- indexed-profunctors-0.1
+- language-avro-0.1.3.1

--- a/modules/haskell-integration-tests/mu-haskell-client-server/stack.yaml
+++ b/modules/haskell-integration-tests/mu-haskell-client-server/stack.yaml
@@ -2,25 +2,25 @@ resolver: lts-14.27
 allow-newer: true
 extra-deps:
 # mu
-- mu-schema-0.2.0.0
-- mu-rpc-0.2.0.0
-- mu-optics-0.2.0.0
-- mu-avro-0.2.0.0
-- mu-protobuf-0.2.0.0
-- mu-grpc-client-0.2.0.0
-- mu-grpc-server-0.2.0.0
-- mu-grpc-common-0.2.0.0
+- mu-schema-0.3.0.0
+- mu-rpc-0.3.0.0
+- mu-optics-0.3.0.0
+- mu-avro-0.3.0.0
+- mu-protobuf-0.3.0.0
+- mu-grpc-client-0.3.0.0
+- mu-grpc-server-0.3.0.0
+- mu-grpc-common-0.3.0.0
 - compendium-client-0.2.0.0
 # dependencies of mu
 - http2-client-0.9.0.0
 - http2-client-grpc-0.8.0.0
 - http2-grpc-types-0.5.0.0
 - http2-grpc-proto3-wire-0.1.0.0
-- warp-grpc-0.3.0.0
+- warp-grpc-0.4.0.1
 - proto3-wire-1.1.0
 - language-protobuf-1.0.1
-- language-avro-0.1.2.0
-- avro-0.4.7.0
+- language-avro-0.1.3.1
+- avro-0.5.1.0
 - HasBigDecimal-0.1.1
 - optics-core-0.2
 - indexed-profunctors-0.1

--- a/modules/haskell-integration-tests/src/test/scala/integrationtest/avro/HaskellServerScalaClientSpec.scala
+++ b/modules/haskell-integration-tests/src/test/scala/integrationtest/avro/HaskellServerScalaClientSpec.scala
@@ -46,17 +46,6 @@ class HaskellServerScalaClientSpec extends AnyFlatSpec with HaskellServerRunning
   behavior of "Mu-Haskell server and Mu-Scala client communication using Avro"
 
   it should "work for a trivial unary call" in {
-    pending
-    // until we upgrade to a version of Mu-Haskell that contains this fix:
-    // https://github.com/haskell-grpc-native/http2-grpc-haskell/pull/20
-    //
-    // However, I think this test may be failing for another reason.  I'm not
-    // sure what the correct behaviour is for a 'void' Avro method in gRPC.
-    // Mu-Scala treats that as "the server returns an `Empty` message", but I
-    // don't know what the Mu-Haskell server is returning. The test fails with
-    // "io.grpc.StatusRuntimeException: INTERNAL: No value received for unary
-    // call".
-
     val response = clientResource
       .use(client => client.ping(Empty))
       .unsafeRunSync()
@@ -64,10 +53,6 @@ class HaskellServerScalaClientSpec extends AnyFlatSpec with HaskellServerRunning
   }
 
   it should "work for a unary call" in {
-    pending
-    // until we upgrade to a version of Mu-Haskell that contains this fix:
-    // https://github.com/haskell-grpc-native/http2-grpc-haskell/pull/20
-
     val request = GetForecastRequest("London", 3)
     val expectedResponse = GetForecastResponse(
       last_updated = "2020-03-20T12:00:00Z",

--- a/modules/haskell-integration-tests/src/test/scala/integrationtest/protobuf/HaskellServerScalaClientSpec.scala
+++ b/modules/haskell-integration-tests/src/test/scala/integrationtest/protobuf/HaskellServerScalaClientSpec.scala
@@ -48,10 +48,6 @@ class HaskellServerScalaClientSpec extends AnyFlatSpec with HaskellServerRunning
   behavior of "Mu-Haskell server and Mu-Scala client communication using Protobuf"
 
   it should "work for a trivial unary call" in {
-    pending
-    // until we upgrade to a version of Mu-Haskell that contains this fix:
-    // https://github.com/haskell-grpc-native/http2-grpc-haskell/pull/20
-
     val response = clientResource
       .use(client => client.ping(Empty))
       .unsafeRunSync()
@@ -59,10 +55,6 @@ class HaskellServerScalaClientSpec extends AnyFlatSpec with HaskellServerRunning
   }
 
   it should "work for a unary call" in {
-    pending
-    // until we upgrade to a version of Mu-Haskell that contains this fix:
-    // https://github.com/haskell-grpc-native/http2-grpc-haskell/pull/20
-
     val request = GetForecastRequest("London", 3)
     val expectedResponse = GetForecastResponse(
       last_updated = "2020-03-20T12:00:00Z",
@@ -75,10 +67,6 @@ class HaskellServerScalaClientSpec extends AnyFlatSpec with HaskellServerRunning
   }
 
   it should "work for a client-streaming call" in {
-    pending
-    // until we upgrade to a version of Mu-Haskell that contains this fix:
-    // https://github.com/haskell-grpc-native/http2-grpc-haskell/pull/20
-
     val stream =
       Stream(STARTED, STOPPED, STARTED, STOPPED, STARTED)
         .map(RainEvent("London", _))
@@ -91,10 +79,6 @@ class HaskellServerScalaClientSpec extends AnyFlatSpec with HaskellServerRunning
   }
 
   it should "work for a server-streaming call" in {
-    pending
-    // until we upgrade to a version of Mu-Haskell that contains this fix:
-    // https://github.com/haskell-grpc-native/http2-grpc-haskell/pull/20
-
     val request = SubscribeToRainEventsRequest("London")
     val events = clientResource
       .use(client =>

--- a/modules/haskell-integration-tests/src/test/scala/integrationtest/protobuf/HaskellServerScalaClientSpec.scala
+++ b/modules/haskell-integration-tests/src/test/scala/integrationtest/protobuf/HaskellServerScalaClientSpec.scala
@@ -81,9 +81,7 @@ class HaskellServerScalaClientSpec extends AnyFlatSpec with HaskellServerRunning
   it should "work for a server-streaming call" in {
     val request = SubscribeToRainEventsRequest("London")
     val events = clientResource
-      .use(client =>
-        Stream.force(client.subscribeToRainEvents(request)).compile.toList
-      )
+      .use(client => Stream.force(client.subscribeToRainEvents(request)).compile.toList)
       .unsafeRunSync()
     val expectedEvents =
       List(STARTED, STOPPED, STARTED, STOPPED, STARTED)


### PR DESCRIPTION
## What this does?

* Upgrade the Mu-Haskell client and server used in the integration tests to v0.3.x.
* Enable some integration tests that were previously `pending`. All tests are now enabled and passing.
* In `stack.yaml`, pin mu-haskell to a git commit (the current `HEAD` of `master`) for now, pending a release of v0.3.1 containing some bugfixes.
* Update the integration tests readme

I've rebuilt the `cb372/mu-haskell-warm-dot-stack` and `cb372/mu-scala-haskell-integration-tests` Docker images on this branch and published them to Dockerhub.

## Checklist

- [x] Reviewed the diff to look for typos, println and format errors.
- [x] Updated the docs accordingly.

