### PR TITLE
Update base image for integration tests Docker images

### DIFF
--- a/modules/haskell-integration-tests/mu-haskell-client-server/Dockerfile
+++ b/modules/haskell-integration-tests/mu-haskell-client-server/Dockerfile
@@ -1,4 +1,4 @@
-FROM fpco/stack-build:lts-14.27 as build
+FROM fpco/stack-build:lts-15.5 as build
 COPY --from=cb372/mu-haskell-warm-dot-stack /root/.stack /root/.stack
 RUN mkdir /opt/build
 RUN mkdir /opt/build/bin

--- a/modules/haskell-integration-tests/mu-haskell-client-server/Dockerfile.warm_dot_stack
+++ b/modules/haskell-integration-tests/mu-haskell-client-server/Dockerfile.warm_dot_stack
@@ -3,8 +3,11 @@
 # This is used to speed up the building of the actual image
 # we want to use for the tests.
 
-FROM fpco/stack-build:lts-14.27
+FROM fpco/stack-build:lts-15.5 AS build
 RUN mkdir /opt/build
 RUN mkdir /opt/build/bin
 COPY . /opt/build
 RUN cd /opt/build && stack build --system-ghc
+
+FROM ubuntu:20.04
+COPY --from=build /root/.stack /root/.stack

--- a/modules/haskell-integration-tests/mu-haskell-client-server/build.sh
+++ b/modules/haskell-integration-tests/mu-haskell-client-server/build.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
 
-docker pull cb372/mu-haskell-warm-dot-stack
+docker pull cb372/mu-haskell-warm-dot-stack:latest
 
 docker build -t cb372/mu-scala-haskell-integration-tests .


### PR DESCRIPTION
Update to the `lts-15.5` tag of the `stack-build` image, to match the LTS in `stack.yaml`.

Also convert `warm_dot_stack` to a multi-stage build, in a last ditch attempt to slim down the images enough to run in a GitHub Actions workflow.


## What this does?
_Changes, features, fixes ..._

## Checklist

- [ ] Reviewed the diff to look for typos, println and format errors.
- [ ] Updated the docs accordingly.