### PR TITLE
Downgrades netty-tcnative-boringssl-static dep

### DIFF
--- a/project/ProjectPlugin.scala
+++ b/project/ProjectPlugin.scala
@@ -34,7 +34,7 @@ object ProjectPlugin extends AutoPlugin {
       val scalalogging: String          = "3.9.2" // used in tests
       val monix: String                 = "3.2.2"
       val natchez: String               = "0.0.11"
-      val nettySSL: String              = "2.0.31.Final"
+      val nettySSL: String              = "2.0.30.Final"
       val paradise: String              = "2.1.1"
       val pbdirect: String              = "0.5.2"
       val prometheus: String            = "0.9.0"


### PR DESCRIPTION
# What this does?

According to [grpc v1.30.2](https://github.com/grpc/grpc-java/blob/v1.30.2/build.gradle#L170), the proper version is `2.0.30.Final`.

## Checklist

- [ ] Reviewed the diff to look for typos, println and format errors.
- [ ] Updated the docs accordingly.

