### PR TITLE
add instructions for manually enabling the sbt-mu-srcgen plugin for versions beyond v0.23.x

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,4 +1,4 @@
-## What this does?
+## What does this change do?
 _Changes, features, fixes ..._
 
 ## Checklist

--- a/microsite/src/main/docs/guides/generate-sources-from-idl/avro.md
+++ b/microsite/src/main/docs/guides/generate-sources-from-idl/avro.md
@@ -15,7 +15,14 @@ First add the sbt plugin in `project/plugins.sbt`:
 addSbtPlugin("io.higherkindness" % "sbt-mu-srcgen" % "@VERSION@")
 ```
 
-Then configure the plugin by adding a few lines to `build.sbt`:
+**NOTE**
+
+For users of the `sbt-mu-srcgen` plugin `v0.22.x` and below, the plugin is enabled automatically as soon as it's added to the `project/plugins.sbt`.  However, for users of the `sbt-mu-srcgen` plugin `v0.23.x` and beyond, the plugin needs to be manually enabled for any module for which you want to generate code.  To enable the module, add the following line to your `build.sbt`
+```scala
+enablePlugins(SrcGenPlugin)
+```
+
+Once the plugin is enabled, you can configure it by adding a few lines to `build.sbt`:
 
 ```scala
 import higherkindness.mu.rpc.srcgen.Model._

--- a/microsite/src/main/docs/guides/generate-sources-from-idl/index.md
+++ b/microsite/src/main/docs/guides/generate-sources-from-idl/index.md
@@ -58,8 +58,6 @@ $ sbt muSrcGen
 
 You will need to add this import at the top of your `build.sbt`:
 
-[TODO ADD ENABLEMENT STEPS FOR SBT PLUGIN]
-
 
 ```scala
 import higherkindness.mu.rpc.srcgen.Model._

--- a/microsite/src/main/docs/guides/generate-sources-from-idl/index.md
+++ b/microsite/src/main/docs/guides/generate-sources-from-idl/index.md
@@ -28,8 +28,17 @@ Mu can generate code from a number of different IDL formats:
 Add the following line to _project/plugins.sbt_:
 
 ```scala
-addSbtPlugin("io.higherkindness" % "sbt-mu-srcgen" % "0.21.3")
+addSbtPlugin("io.higherkindness" % "sbt-mu-srcgen" % "@VERSION@")
 ```
+
+**NOTE**
+
+For users of the `sbt-mu-srcgen` plugin `v0.22.x` and below, the plugin is enabled automatically as soon as it's added to the `project/plugins.sbt`.  However, for users of the `sbt-mu-srcgen` plugin `v0.23.x` and beyond, the plugin needs to be manually enabled for any module for which you want to generate code.  To enable the module, add the following line to your `build.sbt`
+```scala
+enablePlugins(SrcGenPlugin)
+```
+
+Once the plugin is installed and enabled, you can configure it
 
 ## How to use the plugin
 
@@ -48,6 +57,9 @@ $ sbt muSrcGen
 ## Import
 
 You will need to add this import at the top of your `build.sbt`:
+
+[TODO ADD ENABLEMENT STEPS FOR SBT PLUGIN]
+
 
 ```scala
 import higherkindness.mu.rpc.srcgen.Model._

--- a/microsite/src/main/docs/guides/generate-sources-from-idl/proto.md
+++ b/microsite/src/main/docs/guides/generate-sources-from-idl/proto.md
@@ -15,7 +15,14 @@ First add the sbt plugin in `project/plugins.sbt`:
 addSbtPlugin("io.higherkindness" % "sbt-mu-srcgen" % "@VERSION@")
 ```
 
-Then configure the plugin by adding a few lines to `build.sbt`:
+**NOTE**
+
+For users of the `sbt-mu-srcgen` plugin `v0.22.x` and below, the plugin is enabled automatically as soon as it's added to the `project/plugins.sbt`.  However, for users of the `sbt-mu-srcgen` plugin `v0.23.x` and beyond, the plugin needs to be manually enabled for any module for which you want to generate code.  To enable the module, add the following line to your `build.sbt`
+```scala
+enablePlugins(SrcGenPlugin)
+```
+
+Once the plugin is enabled, you can configure it by adding a few lines to `build.sbt`:
 
 ```scala
 import higherkindness.mu.rpc.srcgen.Model._

--- a/microsite/src/main/docs/reference/source-generation.md
+++ b/microsite/src/main/docs/reference/source-generation.md
@@ -14,6 +14,8 @@ Scala source code from Avro/Protobuf/OpenAPI IDL files.
 
 This section explains each of the sbt plugin's settings.
 
+TODO: should I add a section explaining how this plugin is disabled by default, or is that more appropriate in the other settings?
+
 ### muSrcGenIdlType
 
 The most important sbt setting is `muSrcGenIdlType`, which tells the plugin what kind of

--- a/microsite/src/main/docs/reference/source-generation.md
+++ b/microsite/src/main/docs/reference/source-generation.md
@@ -12,9 +12,11 @@ Scala source code from Avro/Protobuf/OpenAPI IDL files.
 
 ## Settings
 
-This section explains each of the sbt plugin's settings.
+This section explains each of the sbt plugin's settings.  As a reminder, this plugin needs to be manually enabled for any module for which you want to generate code; you can do that by adding the following to your `build.sbt`:
 
-TODO: should I add a section explaining how this plugin is disabled by default, or is that more appropriate in the other settings?
+```scala
+enablePlugins(SrcGenPlugin)
+```
 
 ### muSrcGenIdlType
 

--- a/microsite/src/main/docs/tutorials/service-definition/avro.md
+++ b/microsite/src/main/docs/tutorials/service-definition/avro.md
@@ -115,7 +115,6 @@ curly brace.
 
 ## Regenerate the code
 
-
 If you run the `muSrcGen` sbt task again, and inspect the
 `protocol/target/scala-2.13/src_managed/main/com/example/Greeter.scala` file
 again, it should look something like this:

--- a/microsite/src/main/docs/tutorials/service-definition/avro.md
+++ b/microsite/src/main/docs/tutorials/service-definition/avro.md
@@ -115,6 +115,7 @@ curly brace.
 
 ## Regenerate the code
 
+
 If you run the `muSrcGen` sbt task again, and inspect the
 `protocol/target/scala-2.13/src_managed/main/com/example/Greeter.scala` file
 again, it should look something like this:


### PR DESCRIPTION
## What this does?

With this PR (higherkindness/sbt-mu-srcgen#72), we'll need to update the microsite for mu-scala to clarify the correct usage of the sbt-mu-srcgen, since the above change makes it so the plugin is disabled by default and that the users of that plugin will need to update their `build.sbt` files accordingly to take advantage of the new functionality.  

This change is the final piece of the puzzle for this issue: https://github.com/higherkindness/sbt-mu-srcgen/issues/38

## Checklist

- [x] Reviewed the diff to look for typos, println and format errors.
- [x] Updated the docs accordingly.

