### PR TITLE
Update the integration tests to use mu-haskell v0.4

### DIFF
--- a/modules/haskell-integration-tests/README.md
+++ b/modules/haskell-integration-tests/README.md
@@ -67,14 +67,3 @@ much faster.
    (Currently only @cb372 can do this step. If it becomes a major bottleneck, we
    can migrate the image to a `higherkindness` organisation or something.)
 6. Push your changes to GitHub
-
-## Further work
-
-* Add similar tests for Avro.
-* Try to extract these tests into their own repo so they can act as a
-  centralised test suite for both Mu-Scala and Mu-Haskell.
-    * Maybe run nightly, or triggered by a push to master in either repo?
-    * It would need to build the master branch of both Mu-Scala and Mu-Haskell,
-      publish them locally, and make the Haskell server and client and the tests
-      depend on those locally published artifacts. Would also need to build the
-      Docker image before running the tests.

--- a/modules/haskell-integration-tests/mu-haskell-client-server/Dockerfile
+++ b/modules/haskell-integration-tests/mu-haskell-client-server/Dockerfile
@@ -1,5 +1,5 @@
-FROM fpco/stack-build:lts-15.5 as build
-COPY --from=cb372/mu-haskell-warm-dot-stack /root/.stack /root/.stack
+FROM fpco/stack-build:lts-16.20 as build
+COPY --from=cb372/mu-haskell-warm-dot-stack:lts-16.20 /root/.stack /root/.stack
 RUN mkdir /opt/build
 RUN mkdir /opt/build/bin
 COPY . /opt/build

--- a/modules/haskell-integration-tests/mu-haskell-client-server/Dockerfile.warm_dot_stack
+++ b/modules/haskell-integration-tests/mu-haskell-client-server/Dockerfile.warm_dot_stack
@@ -3,7 +3,7 @@
 # This is used to speed up the building of the actual image
 # we want to use for the tests.
 
-FROM fpco/stack-build:lts-15.5 AS build
+FROM fpco/stack-build:lts-16.20 AS build
 RUN mkdir /opt/build
 RUN mkdir /opt/build/bin
 COPY . /opt/build

--- a/modules/haskell-integration-tests/mu-haskell-client-server/build.sh
+++ b/modules/haskell-integration-tests/mu-haskell-client-server/build.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
 
-docker pull cb372/mu-haskell-warm-dot-stack:latest
+docker pull cb372/mu-haskell-warm-dot-stack:lts-16.20
 
-docker build -t cb372/mu-scala-haskell-integration-tests .
+docker build -t cb372/mu-scala-haskell-integration-tests:mu-haskell-0.4.0 .

--- a/modules/haskell-integration-tests/mu-haskell-client-server/mu-haskell-client-server.cabal
+++ b/modules/haskell-integration-tests/mu-haskell-client-server/mu-haskell-client-server.cabal
@@ -17,11 +17,11 @@ library
   default-language:    Haskell2010
   build-depends:       base >= 4.12 && < 5
                      , text
-                     , mu-schema >= 0.3.0
+                     , mu-schema >= 0.3.1
                      , mu-optics >= 0.3.0
-                     , mu-rpc >= 0.3.0
-                     , mu-avro >= 0.3.0
-                     , mu-protobuf >= 0.3.0
+                     , mu-rpc >= 0.4.0
+                     , mu-avro >= 0.4.0
+                     , mu-protobuf >= 0.4.0
 
 executable avro-server
   hs-source-dirs:      avro-server
@@ -29,11 +29,11 @@ executable avro-server
   default-language:    Haskell2010
   build-depends:       base >= 4.12 && < 5
                      , text
-                     , mu-schema >= 0.3.0
+                     , mu-schema >= 0.3.1
                      , mu-optics >= 0.3.0
-                     , mu-rpc >= 0.3.0
-                     , mu-avro >= 0.3.0
-                     , mu-grpc-server >= 0.3.0
+                     , mu-rpc >= 0.4.0
+                     , mu-avro >= 0.4.0
+                     , mu-grpc-server >= 0.4.0
                      , mu-haskell-client-server
 
 executable avro-client
@@ -44,11 +44,11 @@ executable avro-client
                      , text
                      , aeson >= 1.4.6.0
                      , bytestring >= 0.10.8.2
-                     , mu-schema >= 0.3.0
+                     , mu-schema >= 0.3.1
                      , mu-optics >= 0.3.0
-                     , mu-rpc >= 0.3.0
-                     , mu-avro >= 0.3.0
-                     , mu-grpc-client >= 0.3.0
+                     , mu-rpc >= 0.4.0
+                     , mu-avro >= 0.4.0
+                     , mu-grpc-client >= 0.4.0
                      , http2-client-grpc >= 0.8.0.0
                      , mu-haskell-client-server
 
@@ -58,11 +58,11 @@ executable protobuf-server
   default-language:    Haskell2010
   build-depends:       base >= 4.12 && < 5
                      , text
-                     , mu-schema >= 0.3.0
+                     , mu-schema >= 0.3.1
                      , mu-optics >= 0.3.0
-                     , mu-rpc >= 0.3.0
-                     , mu-protobuf >= 0.3.0
-                     , mu-grpc-server >= 0.3.0
+                     , mu-rpc >= 0.4.0
+                     , mu-protobuf >= 0.4.0
+                     , mu-grpc-server >= 0.4.0
                      , conduit >= 1.3.1.2
                      , mu-haskell-client-server
 
@@ -74,11 +74,11 @@ executable protobuf-client
                      , text
                      , aeson >= 1.4.6.0
                      , bytestring >= 0.10.8.2
-                     , mu-schema >= 0.3.0
+                     , mu-schema >= 0.3.1
                      , mu-optics >= 0.3.0
-                     , mu-rpc >= 0.3.0
-                     , mu-protobuf >= 0.3.0
-                     , mu-grpc-client >= 0.3.0
+                     , mu-rpc >= 0.4.0
+                     , mu-protobuf >= 0.4.0
+                     , mu-grpc-client >= 0.4.0
                      , conduit >= 1.3.1.2
                      , http2-client-grpc >= 0.8.0.0
                      , mu-haskell-client-server

--- a/modules/haskell-integration-tests/mu-haskell-client-server/stack.yaml
+++ b/modules/haskell-integration-tests/mu-haskell-client-server/stack.yaml
@@ -2,7 +2,7 @@ resolver: lts-16.20
 allow-newer: true
 extra-deps:
 # mu
-- mu-schema-0.3.1.0
+- mu-schema-0.3.1.1
 - mu-rpc-0.4.0.0
 - mu-optics-0.3.0.0
 - mu-avro-0.4.0.1

--- a/modules/haskell-integration-tests/mu-haskell-client-server/stack.yaml
+++ b/modules/haskell-integration-tests/mu-haskell-client-server/stack.yaml
@@ -1,57 +1,23 @@
-# TODO update this file when mu-haskell is released
-#resolver: lts-15.5
-#allow-newer: true
-#extra-deps:
-## mu
-#- mu-schema-0.3.1.0
-#- mu-rpc-0.3.1.0
-#- mu-optics-0.3.1.0
-#- mu-avro-0.3.1.0
-#- mu-protobuf-0.3.1.0
-#- mu-grpc-client-0.3.1.0
-#- mu-grpc-server-0.3.1.0
-#- mu-grpc-common-0.3.1.0
-#- compendium-client-0.2.0.0
-## dependencies of mu
-#- http2-client-0.9.0.0
-#- http2-client-grpc-0.8.0.0
-#- http2-grpc-proto3-wire-0.1.0.0
-#- http2-grpc-types-0.5.0.0
-#- proto3-wire-1.1.0
-#- warp-grpc-0.4.0.1
-#- hw-kafka-client-3.0.0
-#- hw-kafka-conduit-2.6.0
-#- git: https://github.com/hasura/graphql-parser-hs.git
-#  commit: 1380495a7b3269b70a7ab3081d745a5f54171a9c
-#- avro-0.5.1.0
-#- language-avro-0.1.3.1
-
-resolver: lts-15.5
+resolver: lts-16.20
 allow-newer: true
 extra-deps:
 # mu
-- git: https://github.com/higherkindness/mu-haskell.git
-  commit: e4ec9802643d9a2e3da9c6964dddc1861368401a
-  subdirs:
-  - core/schema
-  - core/rpc
-  - core/optics
-  - adapter/avro
-  - adapter/protobuf
-  - grpc/common
-  - grpc/server
-  - grpc/client
+- mu-schema-0.3.1.0
+- mu-rpc-0.4.0.0
+- mu-optics-0.3.0.0
+- mu-avro-0.4.0.1
+- mu-protobuf-0.4.0.1
+- mu-grpc-client-0.4.0.0
+- mu-grpc-server-0.4.0.0
+- mu-grpc-common-0.4.0.0
 - compendium-client-0.2.0.0
-# dependencies of mu
+# dependencies of mu
 - http2-client-0.9.0.0
 - http2-client-grpc-0.8.0.0
-- http2-grpc-proto3-wire-0.1.0.0
 - http2-grpc-types-0.5.0.0
-- proto3-wire-1.1.0
+- http2-grpc-proto3-wire-0.1.0.0
 - warp-grpc-0.4.0.1
-- hw-kafka-client-3.0.0
-- hw-kafka-conduit-2.6.0
-- git: https://github.com/hasura/graphql-parser-hs.git
-  commit: 1380495a7b3269b70a7ab3081d745a5f54171a9c
+- proto3-wire-1.2.0
+- parameterized-0.5.0.0
 - avro-0.5.1.0
 - language-avro-0.1.3.1

--- a/modules/haskell-integration-tests/src/test/scala/integrationtest/Constants.scala
+++ b/modules/haskell-integration-tests/src/test/scala/integrationtest/Constants.scala
@@ -18,7 +18,7 @@ package integrationtest
 
 object Constants {
 
-  val ImageName = "cb372/mu-scala-haskell-integration-tests:latest"
+  val ImageName = "cb372/mu-scala-haskell-integration-tests:mu-haskell-0.4.0"
 
   val ProtobufPort = 9123
   val AvroPort     = 9124


### PR DESCRIPTION
I've pushed the new images to dockerhub:

- cb372/mu-haskell-warm-dot-stack:lts-16.20
- cb372/mu-scala-haskell-integration-tests:mu-haskell-0.4.0
