### PR TITLE
Update Haskell integration tests due to breaking change in Protobuf handling

### DIFF
--- a/modules/haskell-integration-tests/mu-haskell-client-server/protocol/ProtobufProtocol.hs
+++ b/modules/haskell-integration-tests/mu-haskell-client-server/protocol/ProtobufProtocol.hs
@@ -25,14 +25,14 @@ grpc "WeatherProtocol" id "weather.proto"
 type GetForecastRequest
   = Term WeatherProtocol (WeatherProtocol :/: "GetForecastRequest")
 
-type Weather = Term WeatherProtocol (WeatherProtocol :/: "Weather")
+type Weather = Term WeatherProtocol (WeatherProtocol :/: "GetForecastResponse.Weather")
 
 type GetForecastResponse
   = Term WeatherProtocol (WeatherProtocol :/: "GetForecastResponse")
 
 type RainEvent = Term WeatherProtocol (WeatherProtocol :/: "RainEvent")
 
-type RainEventType = Term WeatherProtocol (WeatherProtocol :/: "RainEventType")
+type RainEventType = Term WeatherProtocol (WeatherProtocol :/: "RainEvent.RainEventType")
 
 started :: RainEventType
 started = enum @"STARTED"

--- a/modules/haskell-integration-tests/mu-haskell-client-server/stack.yaml
+++ b/modules/haskell-integration-tests/mu-haskell-client-server/stack.yaml
@@ -1,16 +1,16 @@
-resolver: lts-16.20
+resolver: lts-16.22
 allow-newer: true
 extra-deps:
 # mu
 - mu-schema-0.3.1.1
-- mu-rpc-0.4.0.0
-- mu-optics-0.3.0.0
-- mu-avro-0.4.0.1
-- mu-protobuf-0.4.0.1
-- mu-grpc-client-0.4.0.0
+- mu-rpc-0.4.0.1
+- mu-optics-0.3.0.1
+- mu-avro-0.4.0.2
+- mu-protobuf-0.4.0.2
+- mu-grpc-client-0.4.0.1
 - mu-grpc-server-0.4.0.0
 - mu-grpc-common-0.4.0.0
-- compendium-client-0.2.0.0
+- compendium-client-0.2.1.1
 # dependencies of mu
 - http2-client-0.9.0.0
 - http2-client-grpc-0.8.0.0
@@ -19,5 +19,3 @@ extra-deps:
 - warp-grpc-0.4.0.1
 - proto3-wire-1.2.0
 - parameterized-0.5.0.0
-- avro-0.5.1.0
-- language-avro-0.1.3.1


### PR DESCRIPTION
## What does this change do?

Due to a breaking change required to handle nested types in Protobuf correctly (https://github.com/higherkindness/mu-haskell/pull/260), the integration tests with Haskell need to be updated.

At the same time, some simplification has been done to the `stack.yaml` file, which no longer has to depend on some non-published packages.

## Checklist

- [X] Reviewed the diff to look for typos, println and format errors.
- [X] Updated the docs accordingly.

