### PR TITLE
Update the docker images for Haskell integration tests

### DIFF
--- a/modules/haskell-integration-tests/mu-haskell-client-server/Dockerfile
+++ b/modules/haskell-integration-tests/mu-haskell-client-server/Dockerfile
@@ -1,5 +1,5 @@
-FROM fpco/stack-build:lts-16.20 as build
-COPY --from=cb372/mu-haskell-warm-dot-stack:lts-16.20 /root/.stack /root/.stack
+FROM fpco/stack-build:lts-16.22 as build
+COPY --from=cb372/mu-haskell-warm-dot-stack:lts-16.22 /root/.stack /root/.stack
 RUN mkdir /opt/build
 RUN mkdir /opt/build/bin
 COPY . /opt/build

--- a/modules/haskell-integration-tests/mu-haskell-client-server/Dockerfile.warm_dot_stack
+++ b/modules/haskell-integration-tests/mu-haskell-client-server/Dockerfile.warm_dot_stack
@@ -3,7 +3,7 @@
 # This is used to speed up the building of the actual image
 # we want to use for the tests.
 
-FROM fpco/stack-build:lts-16.20 AS build
+FROM fpco/stack-build:lts-16.22 AS build
 RUN mkdir /opt/build
 RUN mkdir /opt/build/bin
 COPY . /opt/build

--- a/modules/haskell-integration-tests/mu-haskell-client-server/build.sh
+++ b/modules/haskell-integration-tests/mu-haskell-client-server/build.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
 
-docker pull cb372/mu-haskell-warm-dot-stack:lts-16.20
+docker pull cb372/mu-haskell-warm-dot-stack:lts-16.22
 
-docker build -t cb372/mu-scala-haskell-integration-tests:mu-haskell-0.4.0 .
+docker build -t cb372/mu-scala-haskell-integration-tests:mu-haskell-0.4.0.2 .

--- a/modules/haskell-integration-tests/src/test/scala/integrationtest/Constants.scala
+++ b/modules/haskell-integration-tests/src/test/scala/integrationtest/Constants.scala
@@ -18,7 +18,7 @@ package integrationtest
 
 object Constants {
 
-  val ImageName = "cb372/mu-scala-haskell-integration-tests:mu-haskell-0.4.0"
+  val ImageName = "cb372/mu-scala-haskell-integration-tests:mu-haskell-0.4.0.2"
 
   val ProtobufPort = 9123
   val AvroPort     = 9124


### PR DESCRIPTION
LTS 16.22 and Mu-Haskell 0.4.0.2
