### PR TITLE
Update docs (sbt-mu-srcgen)

### DIFF
--- a/microsite/src/main/docs/guides/generate-sources-from-idl/avro.md
+++ b/microsite/src/main/docs/guides/generate-sources-from-idl/avro.md
@@ -73,7 +73,7 @@ protocol AvroGreeter {
 }
 ```
 
-**NOTE:** please be aware that `mu-scala` restricts Avro RPC method arguments to a single record type and only permits records as return types; 
+**NOTE:** please be aware that `mu-scala` restricts Avro RPC method arguments to a single record type and only permits records as return types;
 for more context, see the [source generation reference](../reference/source-generation).
 
 You can run the source generator directly:

--- a/microsite/src/main/docs/reference/source-generation.md
+++ b/microsite/src/main/docs/reference/source-generation.md
@@ -67,6 +67,7 @@ muSrcGenSerializationType := SerializationType.Protobuf // or SerializationType.
 | `muSrcGenIdlExtension` | The extension of IDL files to extract from JAR files or sbt modules. | * `avdl` if `muSrcGenIdlType` is `avro`<br/> * `proto` if `muSrcGenIdlType` is `Proto` |
 | `muSrcGenCompressionType` | The compression type that will be used by generated RPC services. Set to `higherkindness.mu.rpc.srcgen.Model.GzipGen` for Gzip compression. | `higherkindness.mu.rpc.srcgen.Model.NoCompressionGen` |
 | `muSrcGenIdiomaticEndpoints` | Flag indicating if idiomatic gRPC endpoints should be used. If `true`, the service operations will be prefixed by the namespace. | `true` |
+| `muSrcGenAvroGeneratorType` | Allows to generate Scala code either using [avrohugger](https://github.com/julianpeeters/avrohugger) or [skeuomorph](https://github.com/higherkindness/skeuomorph). `AvroGeneratorTypeGen.SkeumorphGen` is the default; set to `AvroGeneratorTypeGen.AvrohuggerGen` to use the [avrohugger](https://github.com/julianpeeters/avrohugger) library to generate the Scala code. | `AvroGeneratorTypeGen.SkeumorphGen` |
 | `muSrcGenStreamingImplementation` | Specifies whether generated Scala code will use FS2 `Stream[F, A]` or Monix `Observable[A]` as its streaming implementation. FS2 is the default; set to `higherkindness.mu.rpc.srcgen.Model.MonixObservable` to use Monix `Observable[A]` as its streaming implementation. This setting is only relevant if you have any RPC endpoint definitions that involve streaming. | `higherkindness.mu.rpc.srcgen.Model.Fs2Stream` |
 
 
@@ -122,7 +123,7 @@ protocol UserV1 {
 
 the source generation command (i.e. `muSrcGen`) will fail and return all the incompatible
 Avro schema records (for example, the above schema would trigger the following 
-message: 
+message:
 
 ```
 [error] (protocol / muSrcGen) One or more IDL files are invalid. Error details:
@@ -142,7 +143,7 @@ record SearchRequest {
 
 SearchResponse search(SearchRequest request);
 ```
-This schema can be evolved to add optional fields (e.g. ordering, filters, ...) to the request.  All the user has to do is just change the _single record_.  
+This schema can be evolved to add optional fields (e.g. ordering, filters, ...) to the request.  All the user has to do is just change the _single record_.
 
 This API design, on the other hand, can't be evolved because changing the `SearchResponse` argument from a `string` to any other datatype would introduce backward incompatibility.
 

--- a/project/ProjectPlugin.scala
+++ b/project/ProjectPlugin.scala
@@ -34,7 +34,7 @@ object ProjectPlugin extends AutoPlugin {
       val scalalogging: String          = "3.9.3" // used in tests
       val monix: String                 = "3.3.0"
       val natchez: String               = "0.0.22"
-      val nettySSL: String              = "2.0.38.Final"
+      val nettySSL: String              = "2.0.34.Final"
       val paradise: String              = "2.1.1"
       val pbdirect: String              = "0.6.1"
       val prometheus: String            = "0.10.0"

--- a/project/ProjectPlugin.scala
+++ b/project/ProjectPlugin.scala
@@ -174,13 +174,13 @@ object ProjectPlugin extends AutoPlugin {
     )
 
     lazy val benchmarksSettings: Seq[Def.Setting[_]] = Seq(
-      unmanagedSourceDirectories in Compile += {
+      Compile / unmanagedSourceDirectories += {
         baseDirectory.value.getParentFile / "shared" / "src" / "main" / "scala"
       },
-      unmanagedResourceDirectories in Compile += {
+      Compile / unmanagedResourceDirectories += {
         baseDirectory.value.getParentFile / "shared" / "src" / "main" / "resources"
       },
-      unmanagedSourceDirectories in Test += {
+      Test / unmanagedSourceDirectories += {
         baseDirectory.value.getParentFile / "shared" / "src" / "test" / "scala"
       },
       libraryDependencies ++= Seq(
@@ -205,7 +205,7 @@ object ProjectPlugin extends AutoPlugin {
       micrositeGitterChannelUrl := "47deg/mu",
       micrositeOrganizationHomepage := "https://www.47deg.com",
       micrositePushSiteWith := GitHub4s,
-      mdocIn := (sourceDirectory in Compile).value / "docs",
+      mdocIn := (Compile / sourceDirectory).value / "docs",
       micrositeGithubToken := Option(System.getenv().get("GITHUB_TOKEN")),
       micrositePalette := Map(
         "brand-primary"   -> "#001e38",
@@ -290,7 +290,7 @@ object ProjectPlugin extends AutoPlugin {
   override def projectSettings: Seq[Def.Setting[_]] =
     Seq(
       Test / fork := true,
-      compileOrder in Compile := CompileOrder.JavaThenScala,
+      Compile / compileOrder := CompileOrder.JavaThenScala,
       coverageFailOnMinimum := false,
       addCompilerPlugin(
         "org.typelevel" % "kind-projector" % V.kindProjector cross CrossVersion.full

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version = 1.4.9
+sbt.version = 1.5.0


### PR DESCRIPTION
## What does this change do?

This PR updates docs based on https://github.com/higherkindness/sbt-mu-srcgen/pull/159.

Additionally, it upgrades to sbt 1.5.0, removing deprecation warnings related to the old sbt syntax.

## Checklist

- [x] Reviewed the diff to look for typos, println and format errors.
- [x] Updated the docs accordingly.

