### PR TITLE
Restores `fatal-warnings`

### DIFF
--- a/project/ProjectPlugin.scala
+++ b/project/ProjectPlugin.scala
@@ -103,8 +103,7 @@ object ProjectPlugin extends AutoPlugin {
       libraryDependencies ++= Seq(
         "org.typelevel" %% "cats-effect" % V.catsEffect
       ),
-      muSrcGenIdlType := IdlType.Proto,
-      scalacOptions ~= (_ filterNot Set("-Xfatal-warnings"))
+      muSrcGenIdlType := IdlType.Proto
     )
 
     lazy val serverSettings: Seq[Def.Setting[_]] = Seq(
@@ -228,13 +227,11 @@ object ProjectPlugin extends AutoPlugin {
         "org.typelevel"          %% "munit-cats-effect-3"     % V.munitCE               % Test,
         "org.typelevel"          %% "cats-effect-testkit"     % V.catsEffect            % Test,
         "ch.qos.logback"          % "logback-classic"         % V.logback               % Test
-      ),
-      scalacOptions ~= (_ filterNot Set("-Xfatal-warnings"))
+      )
     )
 
     lazy val protobufSrcGenSettings = Seq(
-      muSrcGenIdlType := IdlType.Proto,
-      scalacOptions ~= (_ filterNot Set("-Xfatal-warnings"))
+      muSrcGenIdlType := IdlType.Proto
     )
 
     lazy val protobufRPCTestSettings = testSettings ++ protobufSrcGenSettings
@@ -251,8 +248,7 @@ object ProjectPlugin extends AutoPlugin {
             ScalacOptions.warnUnusedImports
           )
         )
-      },
-      scalacOptions ~= (_ filterNot Set("-Xfatal-warnings"))
+      }
     )
 
     lazy val avroRPCTestSettings = testSettings ++ avroSrcGenSettings

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -15,7 +15,4 @@ addSbtPlugin("com.alejandrohdezma"       % "sbt-github-mdoc"          % "0.11.6"
 addSbtPlugin("com.alejandrohdezma"       % "sbt-remove-test-from-pom" % "0.1.0")
 addSbtPlugin("io.github.davidgregory084" % "sbt-tpolecat"             % "0.3.1")
 addSbtPlugin("ch.epfl.scala"             % "sbt-missinglink"          % "0.3.3")
-
-resolvers += Resolver.sonatypeRepo("snapshots")
-// Update once sbt-mu-srcgen is released
-addSbtPlugin("io.higherkindness" % "sbt-mu-srcgen" % "0.29.1+17-6bd76481-SNAPSHOT")
+addSbtPlugin("io.higherkindness"         % "sbt-mu-srcgen"            % "0.30.0")


### PR DESCRIPTION
## What does this change do?

The new version of the srcgen plugin generates code without warnings. This PR bumps the plugin version and restores the `fatal-warnings` option for the scala compiler.

## Checklist

- [x] Reviewed the diff to look for typos, println and format errors.
- [x] Updated the docs accordingly.

