### PR TITLE
Updates docker it library

### DIFF
--- a/modules/haskell-integration-tests/mu-haskell-client-server/stack.yaml
+++ b/modules/haskell-integration-tests/mu-haskell-client-server/stack.yaml
@@ -11,7 +11,7 @@ extra-deps:
 - mu-grpc-server-0.4.0.0
 - mu-grpc-common-0.4.0.0
 - compendium-client-0.2.1.1
-# dependencies of mu
+# dependencies of mu
 - http2-client-0.9.0.0
 - http2-client-grpc-0.8.0.0
 - http2-grpc-types-0.5.0.0

--- a/modules/haskell-integration-tests/src/test/scala/integrationtest/HaskellServerRunningInDocker.scala
+++ b/modules/haskell-integration-tests/src/test/scala/integrationtest/HaskellServerRunningInDocker.scala
@@ -16,32 +16,54 @@
 
 package integrationtest
 
-import com.whisk.docker.DockerContainer
-import com.whisk.docker.impl.spotify.DockerKitSpotify
+import com.spotify.docker.client.messages.PortBinding
+import com.spotify.docker.client.{DefaultDockerClient, DockerClient}
+import com.whisk.docker.testkit.{
+  ContainerCommandExecutor,
+  ContainerSpec,
+  DockerContainerManager,
+  DockerTestTimeouts,
+  ManagedContainers
+}
 
-trait HaskellServerRunningInDocker extends DockerKitSpotify { self: munit.FunSuite =>
+import java.util.concurrent.ForkJoinPool
+import scala.concurrent.ExecutionContext
+
+trait HaskellServerRunningInDocker { self: munit.FunSuite =>
 
   def serverPort: Int
   def serverExecutableName: String
 
-  override def dockerContainers: List[DockerContainer] =
-    List(
-      DockerContainer(Constants.ImageName)
-        .withPorts(serverPort -> Some(serverPort))
-        .withCommand(s"/opt/mu-haskell-client-server/$serverExecutableName")
-    )
+  val dockerClient: DockerClient = DefaultDockerClient.fromEnv().build()
 
-  override def startAllOrFail(): Unit = {
+  val dockerExecutionContext: ExecutionContext = ExecutionContext.fromExecutor(new ForkJoinPool())
+
+  val managedContainers: ManagedContainers = ContainerSpec(Constants.ImageName)
+    .withPortBindings(serverPort -> PortBinding.of("0.0.0.0", serverPort))
+    .withCommand(s"/opt/mu-haskell-client-server/$serverExecutableName")
+    .toContainer
+    .toManagedContainer
+
+  val dockerTestTimeouts: DockerTestTimeouts = DockerTestTimeouts.Default
+
+  implicit lazy val dockerExecutor: ContainerCommandExecutor =
+    new ContainerCommandExecutor(dockerClient)
+
+  lazy val containerManager = new DockerContainerManager(
+    managedContainers,
+    dockerExecutor,
+    dockerTestTimeouts,
+    dockerExecutionContext
+  )
+
+  override def beforeAll(): Unit = {
     println("Starting Mu-Haskell server in Docker container...")
-    super.startAllOrFail()
+    containerManager.start()
     println("Started Docker container.")
     Thread.sleep(2000) // give the Haskell server a chance to start up properly
   }
 
-  override def beforeAll(): Unit =
-    startAllOrFail()
-
   override def afterAll(): Unit =
-    stopAllQuietly()
+    containerManager.stop()
 
 }

--- a/project/ProjectPlugin.scala
+++ b/project/ProjectPlugin.scala
@@ -19,7 +19,7 @@ object ProjectPlugin extends AutoPlugin {
     lazy val V = new {
       val avro4s: String                = "4.1.0"
       val catsEffect: String            = "3.4.6"
-      val dockerItScala                 = "0.9.9"
+      val dockerItScala                 = "0.11.0"
       val dropwizard: String            = "4.2.15"
       val enumeratum: String            = "1.7.2"
       val fs2: String                   = "3.6.1"
@@ -257,10 +257,10 @@ object ProjectPlugin extends AutoPlugin {
       publishArtifact          := false,
       Test / parallelExecution := false,
       libraryDependencies ++= Seq(
-        "co.fs2"        %% "fs2-core"                    % V.fs2,
-        "org.scalameta" %% "munit"                       % V.munit         % Test,
-        "org.typelevel" %% "munit-cats-effect-3"         % V.munitCE       % Test,
-        "com.whisk"     %% "docker-testkit-impl-spotify" % V.dockerItScala % Test
+        "co.fs2"        %% "fs2-core"                 % V.fs2,
+        "org.scalameta" %% "munit"                    % V.munit         % Test,
+        "org.typelevel" %% "munit-cats-effect-3"      % V.munitCE       % Test,
+        "com.whisk"     %% "docker-testkit-scalatest" % V.dockerItScala % Test
       )
     )
 


### PR DESCRIPTION
## What does this change do?

Updates the `docker-testkit` library. The module `docker-testkit-impl-spotify` is no longer published. This uses the base library.

## Checklist

- [x] Reviewed the diff to look for typos, println and format errors.
- [x] Updated the docs accordingly.

