### PR TITLE
Bumps Netty SSL (netty-tcnative-boringssl-static)

### DIFF
--- a/project/ProjectPlugin.scala
+++ b/project/ProjectPlugin.scala
@@ -33,7 +33,7 @@ object ProjectPlugin extends AutoPlugin {
       val munit: String                 = "0.7.29"
       val munitCE: String               = "1.0.7"
       val natchez: String               = "0.3.3"
-      val nettySSL: String              = "2.0.54.Final"
+      val nettySSL: String              = "2.0.61.Final"
       val paradise: String              = "2.1.1"
       val pbdirect: String              = "0.7.0"
       val prometheus: String            = "0.16.0"


### PR DESCRIPTION
## What does this change do?

Aligns netty-tcnative-boringssl-static version with grpc:

https://github.com/grpc/grpc-java/blob/master/SECURITY.md#netty

