### PR TITLE
Bumps Scala and updates CI for Java 17

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,6 +13,8 @@ jobs:
   test:
     if: "!contains(github.event.head_commit.message, 'skip ci')"
     runs-on: ubuntu-latest
+    env:
+      JAVA_OPTS: -Xms2048M -Xmx2048M -Xss6M -XX:ReservedCodeCacheSize=256M -Dfile.encoding=UTF-8
     steps:
       - name: Checkout project (pull-request)
         if: github.event_name == 'pull_request'
@@ -23,10 +25,13 @@ jobs:
       - name: Checkout project (main)
         if: github.event_name == 'push'
         uses: actions/checkout@v2
-      - name: Setup Scala
-        uses: olafurpg/setup-scala@v11
+      - name: Setup JDK
+        uses: actions/setup-java@v4
         with:
-          java-version: adopt@1.11
+          distribution: temurin
+          java-version: 17
+          cache: sbt
+      - uses: sbt/setup-sbt@v1
       - name: Setup Ruby
         uses: ruby/setup-ruby@v1
         with:

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -14,6 +14,8 @@ jobs:
   documentation:
     if: "!contains(github.event.head_commit.message, 'skip ci')"
     runs-on: ubuntu-latest
+    env:
+      JAVA_OPTS: -Xms2048M -Xmx2048M -Xss6M -XX:ReservedCodeCacheSize=256M -Dfile.encoding=UTF-8
     steps:
       - name: Checkout project
         uses: actions/checkout@v2
@@ -22,10 +24,13 @@ jobs:
           ref: main
       - name: Fetch tags
         run: git fetch --tags
-      - name: Setup Scala
-        uses: olafurpg/setup-scala@v11
+      - name: Setup JDK
+        uses: actions/setup-java@v4
         with:
-          java-version: adopt@1.11
+          distribution: temurin
+          java-version: 17
+          cache: sbt
+      - uses: sbt/setup-sbt@v1
       - name: Setup Ruby
         uses: ruby/setup-ruby@v1
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,6 +14,8 @@ jobs:
   release:
     if: "!contains(github.event.head_commit.message, 'skip ci')"
     runs-on: ubuntu-latest
+    env:
+      JAVA_OPTS: -Xms2048M -Xmx2048M -Xss6M -XX:ReservedCodeCacheSize=256M -Dfile.encoding=UTF-8
     steps:
       - name: Checkout project
         uses: actions/checkout@v2
@@ -21,10 +23,14 @@ jobs:
           fetch-depth: 0
       - name: Fetch tags
         run: git fetch --tags
-      - name: Setup Scala
-        uses: olafurpg/setup-scala@v11
+      - uses: actions/checkout@v4
+      - name: Setup JDK
+        uses: actions/setup-java@v4
         with:
-          java-version: adopt@1.11
+          distribution: temurin
+          java-version: 17
+          cache: sbt
+      - uses: sbt/setup-sbt@v1
       - name: Setup Ruby
         uses: ruby/setup-ruby@v1
         with:

--- a/build.sbt
+++ b/build.sbt
@@ -1,5 +1,5 @@
 val scala213 = "2.13.16"
-val scala3   = "3.4.3"
+val scala3   = "3.6.3"
 
 ThisBuild / organization       := "io.higherkindness"
 ThisBuild / githubOrganization := "47degrees"


### PR DESCRIPTION
## What does this change do?

Using [actions/setup-java](https://github.com/actions/setup-java)) and [actions/setup-sbt](https://github.com/sbt/setup-sbt) to select the Java version and install SBT. The `olafurpg` action is discontinued.

## Checklist

- [ ] Reviewed the diff to look for typos, println and format errors.
- [ ] Updated the docs accordingly.

